### PR TITLE
Change most HTML to Markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,36 @@
-<h1 align="center">
-    <a href="https://github.com/null2264/yokai"><img src="./.github/readme-images/app-icon.png" alt="app icon" width="200" /></a>
-    <br/>
-    Yōkai
-</h1>
-<p align="center">A free and open source manga reader</p>
+<div align="center">
 
-<p id="badges" align="center">
-    <a href="https://github.com/null2264/yokai/actions/workflows/build_push.yml"><img alt="CI" src="https://github.com/null2264/yokai/actions/workflows/build_push.yml/badge.svg" /></a>
-    <a href="/LICENSE"><img alt="License: Apache-2.0" src="https://img.shields.io/badge/license-Apache--2.0-blue.svg" /></a>
-</p>
+<a href="https://github.com/null2264/yokai">
+    <img src="./.github/readme-images/app-icon.png" alt="Yokai logo" height="200px" width="200px" />
+</a>
 
-<p align="center">
-    <img alt="Screenshot" src="./.github/readme-images/screens.gif" />
-</p>
+# Yōkai
 
-<h2 align="center">Download</h2>
+A free and open source manga reader
 
-<p id="badges" align="center">
-    <a href="https://github.com/null2264/yokai/releases"><img alt="GitHub Releases" src="https://img.shields.io/github/v/release/null2264/yokai?maxAge=3600&label=Stable&labelColor=06599d&color=043b69&filter=v*"></a>
-    <a href="https://github.com/null2264/yokai/releases"><img alt="GitHub Releases" src="https://img.shields.io/github/v/release/null2264/yokai?maxAge=3600&label=Nightly&labelColor=2c2c47&color=1c1c39&filter=r*"></a>
-    <br/>
-    <em>Requires Android 6.0 or higher.</em>
-</p>
+[![CI](https://github.com/null2264/yokai/actions/workflows/build_push.yml/badge.svg)](https://github.com/null2264/yokai/actions/workflows/build_push.yml)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](/LICENSE)
 
-<h2 align="center">About Fork</h2>
+<img src="./.github/readme-images/screens.gif" alt="Yokai screenshot" height="412px" width="800px" />
 
-<p align="center">This fork was created for personal usage, the name Yōkai is chosen in theme of my "paranormal" fork collection, all of them are made for personal purposes, to explore the language used to made them, explore new tech, or simply want to add my own twists that may not accepted by upstream as a PR.</p>
+## Download
 
-<h2 align="center">Features</h2>
+[![Yokai Stable](https://img.shields.io/github/v/release/null2264/yokai?maxAge=3600&label=Stable&labelColor=06599d&color=043b69&filter=v*)](https://github.com/null2264/yokai/releases)
+[![Yokai Nightly](https://img.shields.io/github/v/release/null2264/yokai?maxAge=3600&label=Nightly&labelColor=2c2c47&color=1c1c39&filter=r*)](https://github.com/null2264/yokai/releases)
+
+*Requires Android 6.0 or higher.*
+
+## About Fork
+
+This fork was created for personal usage, the name Yōkai is chosen in theme of my "paranormal" fork collection, all of them are made for personal purposes, to explore the language used to made them, explore new tech, or simply want to add my own twists that may not accepted by upstream as a PR.
+
+## Features
+
+<div align="left">
 
 ### Features of Tachiyomi include
-* Local reading of downloaded content
+
+* Local reading of downloaded content.
 * A configurable reader with multiple viewers, reading directions and other settings.
 * Tracker support:
   [MyAnimeList](https://myanimelist.net/),
@@ -38,36 +38,41 @@
   [Kitsu](https://kitsu.io/explore/anime),
   [Manga Updates](https://www.mangaupdates.com/),
   [Shikimori](https://shikimori.one),
-  and [Bangumi](https://bgm.tv/) support
-* Categories to organize your library
-* Light and dark themes
-* Schedule updating your library for new chapters
-* Create backups locally to read offline or to your desired cloud service 
+  and [Bangumi](https://bgm.tv/) support.
+* Categories to organize your library.
+* Light and dark themes.
+* Schedule updating your library for new chapters.
+* Create backups locally to read offline or to your desired cloud service.
 
 ### Plus some new features in this fork and J2K such as
-* UI redesign
-* New Manga details screens, themed by their manga covers
-* Combine 2 pages while reading into a single one for a better tablet experience
-* An expanded toolbar for easier one handed use (with the option to reduce the size back down)
-* Floating searchbar to easily start a search in your library or while browsing
-* Library redesigned as a single list view: See categories listed in a vertical view, that can be collasped or expanded with a tap
-* Staggered Library grid
-* Drag & Drop Sorting in Library
-* Dynamic Categories: Group your library automatically by the tags, tracking status, source, and more
-* New Recents page: Providing quick access to newly added manga, new chapters, and to continue where you left on in a series
-* Stats Page
-* New Themes
-* Dynamic Shortcuts: open the latest chapter of what you were last reading right from your homescreen
-* [New material snackbar](.github/readme-images/material%20snackbar.png): Removing manga now auto deletes chapters and has an undo button in case you change your mind
-* Batch Auto-Source Migration (taken from [TachiyomiEH](https://github.com/NerdNumber9/TachiyomiEH))
+
+* UI redesign.
+* New Manga details screens, themed by their manga covers.
+* Combine 2 pages while reading into a single one for a better tablet experience.
+* An expanded toolbar for easier one handed use (with the option to reduce the size back down).
+* Floating searchbar to easily start a search in your library or while browsing.
+* Library redesigned as a single list view: See categories listed in a vertical view, that can be collasped or expanded with a tap.
+* Staggered Library grid.
+* Drag & Drop Sorting in Library.
+* Dynamic Categories: Group your library automatically by the tags, tracking status, source, and more.
+* New Recents page: Providing quick access to newly added manga, new chapters, and to continue where you left on in a series.
+* Stats Page.
+* New Themes.
+* Dynamic Shortcuts: open the latest chapter of what you were last reading right from your homescreen.
+* [New material snackbar](.github/readme-images/material%20snackbar.png): Removing manga now auto deletes chapters and has an undo button in case you change your mind.
+* Batch Auto-Source Migration (taken from [TachiyomiEH](https://github.com/NerdNumber9/TachiyomiEH)).
 * [Share sheets upgrade for Android 10](.github/readme-images/share%20menu.png)
-* View all chapters right in the reader
-* A lot more Material Design You additions
-* Android 12 features such as automatic extension and app updates
+* View all chapters right in the reader.
+* A lot more Material Design You additions.
+* Android 12 features such as automatic extension and app updates.
 
-<h2 align="center">Contributing</h2>
+</div>
 
-<p align="center">Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.</p>
+## Contributing
+
+Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
+
+<div align="left">
 
 <details><summary>Issues</summary>
 
@@ -77,43 +82,42 @@
 
 <details><summary>Bugs</summary>
 
-* Include version (Setting > About > Version)
- * If not latest, try updating, it may have already been solved
- * Dev version is equal to the number of commits as seen in the main page
-* Include steps to reproduce (if not obvious from description)
-* Include screenshot (if needed)
-* If it could be device-dependent, try reproducing on another device (if possible)
-* For large logs use http://pastebin.com/ (or similar)
-* Don't group unrelated requests into one issue
-
-DO: https://github.com/tachiyomiorg/tachiyomi/issues/24 https://github.com/tachiyomiorg/tachiyomi/issues/71
-
-DON'T: https://github.com/tachiyomiorg/tachiyomi/issues/75
+* Include version (**Settings → About → Version**).
+  * If not latest, try updating, it may have already been solved.
+  * Dev version is equal to the number of commits as seen in the main page.
+* Include steps to reproduce (if not obvious from description).
+* Include screenshot (if needed).
+* If it could be device-dependent, try reproducing on another device (if possible).
+* For large logs use [Pastebin](https://pastebin.com/) (or similar).
+* Don't group unrelated requests into one issue.
+- **DO**: [Example #1](https://github.com/tachiyomiorg/tachiyomi/issues/24), [Example #2](https://github.com/tachiyomiorg/tachiyomi/issues/71).
+- **DON'T**: [Example #1](https://github.com/tachiyomiorg/tachiyomi/issues/75).
 
 </details>
 
 <details><summary>Feature Requests</summary>
 
-* Write a detailed issue, explaning what it should do or how. Avoid writing just "like X app does"
-* Include screenshot (if needed)
+* Write a detailed issue, explaning what it should do or how.
+  * Avoid writing just "like X app does"
+* Include screenshot (if needed).
 
 </details>
 
+</div>
 
-<h2 align="center">Credits</h2>
+### Credits
 
-<p align="center">Thank you to all the people who have already contributed!</p>
-<p align="center">
-    <a href="https://github.com/mihonapp/mihon/graphs/contributors">
-        <img src="https://contrib.rocks/image?repo=mihonapp/mihon" width="600"/>
-    </a>
-</p>
+Thank you to all the people who have contributed!
 
-<h2 align="center">Disclaimer</h2>
+<a href="https://github.com/null2264/yokai/graphs/contributors">
+    <img src="https://contrib.rocks/image?repo=null2264/yokai" alt="Yokai app contributors" title="Yokai app contributors" width="600"/>
+</a>
 
-<p align="center">The developer(s) of this application does not have any affiliation with the content providers available, and this application hosts zero content.</p>
+### Disclaimer
 
-<h2 align="center">License</h2>
+The developer(s) of this application does not have any affiliation with the content providers available, and this application hosts zero content.
+
+### License
 
     Copyright 2015 Javier Tomás
 
@@ -129,3 +133,4 @@ DON'T: https://github.com/tachiyomiorg/tachiyomi/issues/75
     See the License for the specific language governing permissions and
     limitations under the License.
 
+</div>


### PR DESCRIPTION
Change most HTML to Markdown
Kept HTML for the images requiring custom dimensions (prevent page jumping
Also fixes contributor list as it was set to Mihon's repo