### PR TITLE
fix: staggered grid cover being squashed for local source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Fix certain Infinix devices being unable to use any "Open link in browser" actions, including tracker setup (@MajorTanya)
 - Fix source filter bottom sheet unable to be fully scrolled to the bottom
 - Prevent potential "Comparison method violates its general contract!" crash
-
+- Fix staggered grid cover being squashed for local source
+  
 ### Translation
 - Update translations from Weblate
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaCoverMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaCoverMetadata.kt
@@ -10,6 +10,7 @@ import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.domain.manga.models.Manga
 import java.util.concurrent.ConcurrentHashMap
 import uy.kohesive.injekt.injectLazy
+import kotlin.jvm.Throws
 
 /** Object that holds info about a covers size ratio + dominant colors */
 object MangaCoverMetadata {
@@ -66,7 +67,12 @@ object MangaCoverMetadata {
             } else {
                 options.inSampleSize = 4
             }
-            val bitmap = BitmapFactory.decodeFile(file.filePath, options)
+            val bitmap = try {
+                val stream = file.openInputStream()
+                BitmapFactory.decodeStream(stream, null, options)
+            } catch (_: Throwable) {
+                null
+            }
             if (bitmap != null) {
                 Palette.from(bitmap).generate { palette ->
                     if (isInLibrary) {

--- a/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaCoverMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/manga/MangaCoverMetadata.kt
@@ -10,7 +10,6 @@ import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.domain.manga.models.Manga
 import java.util.concurrent.ConcurrentHashMap
 import uy.kohesive.injekt.injectLazy
-import kotlin.jvm.Throws
 
 /** Object that holds info about a covers size ratio + dominant colors */
 object MangaCoverMetadata {


### PR DESCRIPTION
outWidth and outHeight from `BitmapFactory.Options()` are always 0 when file is in external storage (not app's data dir) aka local source for some reason, which caused the ratio to be NaN (0/0).
According to [this SO answer](https://stackoverflow.com/a/27899762), using the stream to decode it fixes it, which I have confirmed by testing.

closes #341