### PR TITLE
fix(deps): Revert update xml.serialization to v0.90.3

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/CustomMangaManager.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/CustomMangaManager.kt
@@ -12,7 +12,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
-import nl.adaptivity.xmlutil.core.AndroidXmlReader
+import nl.adaptivity.xmlutil.AndroidXmlReader
 import nl.adaptivity.xmlutil.serialization.XML
 import nl.adaptivity.xmlutil.serialization.XmlSerialName
 import nl.adaptivity.xmlutil.serialization.XmlValue

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
-import nl.adaptivity.xmlutil.core.AndroidXmlReader
+import nl.adaptivity.xmlutil.AndroidXmlReader
 import nl.adaptivity.xmlutil.serialization.XML
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get

--- a/gradle/kotlinx.versions.toml
+++ b/gradle/kotlinx.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.1.0"
 serialization = "1.7.3"
-xml_serialization = "0.90.3"
+xml_serialization = "0.86.3"
 
 [libraries]
 gradle = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
Reverts the xml.serialization update from v0.90.3 to v0.86.3 because it causes a crash when leaving a manga open in the background in the info/chapters section of local source
<!--
^ Please summarise the changes you have made here ^
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
