### PR TITLE
refactor: Replace Requery's SQLite with AndroidX's new KMP SQLite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Refactor Library to store LibraryMap instead of flatten list of LibraryItem
   - LibraryItem abstraction to make it easier to manage
   - LibraryManga no longer extend MangaImpl
+- Replace Requery's SQLite with AndroidX's new KMP SQLite
 - Update dependency gradle to v8.12
 - Update user agent (@Hiirbaf)
 - Update serialization to v1.8.1
@@ -65,8 +66,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update dependency com.getkeepsafe.taptargetview:taptargetview to v1.15.0
 - Update dependency androidx.window:window to v1.4.0
 - Update dependency androidx.webkit:webkit to v1.13.0
-- Update dependency androidx.sqlite:sqlite-ktx to v2.5.1
-- Update dependency androidx.sqlite:sqlite to v2.5.1
+- Update androidxSqlite to v2.5.1
 - Update dependency androidx.recyclerview:recyclerview to v1.4.0
 - Update dependency androidx.core:core-ktx to v1.16.0
 - Update dependency androidx.compose:compose-bom to v2025.05.01

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -200,7 +200,6 @@ dependencies {
     implementation(libs.play.services.gcm)
 
     // Database
-    implementation(libs.sqlite.android)
     implementation(libs.bundles.sqlite)
 
     // Model View Presenter

--- a/gradle/androidx.versions.toml
+++ b/gradle/androidx.versions.toml
@@ -28,7 +28,6 @@ multidex = { module = "androidx.multidex:multidex", version = "2.0.1" }
 palette = { module = "androidx.palette:palette", version = "1.0.0" }
 preference = { module = "androidx.preference:preference-ktx", version = "1.2.1" }
 recyclerview = { module = "androidx.recyclerview:recyclerview", version = "1.4.0" }
-sqlite = { module = "androidx.sqlite:sqlite", version = "2.5.1" }
 webkit = { module = "androidx.webkit:webkit", version = "1.13.0" }
 work = { module = "androidx.work:work-runtime-ktx", version = "2.10.1" }
 window = { module = "androidx.window:window", version = "1.4.0" }
@@ -38,7 +37,7 @@ androidx = [
     "activity", "activity-compose", "annotation", "appcompat", "browser", "biometric", "cardview", "core",
     "core-splashscreen", "layout-constraint", "glance-appwidget", "lifecycle-common", "lifecycle-livedata",
     "lifecycle-process", "lifecycle-runtime", "lifecycle-viewmodel", "lifecycle-viewmodel-compose", "multidex",
-    "palette", "preference", "recyclerview", "sqlite", "layout-swiperefresh", "webkit", "work", "window"
+    "palette", "preference", "recyclerview", "layout-swiperefresh", "webkit", "work", "window"
 ]
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,9 +6,9 @@ fast_adapter = "5.7.0"
 moko = "0.24.5"
 okhttp = "5.0.0-alpha.16"
 shizuku = "13.1.5"
-# FIXME: Uncomment once SQLDelight support KMP AndroidX SQLiteDriver
-#sqlite = "2.5.0-alpha04"
-sqlite = "2.5.1"
+androidxSqlite = "2.5.1"
+# FIXME: Stay at 2.0.2 until 2.1.1 released because dialect is borked
+# REF: https://github.com/sqldelight/sqldelight/issues/5758
 sqldelight = "2.0.2"
 junit = "5.11.3"
 kermit = "2.0.5"
@@ -82,13 +82,12 @@ rxjava = { module = "io.reactivex:rxjava", version = "1.3.8" }
 rxandroid = { module = "io.reactivex:rxandroid", version = "1.2.1" }
 slice = { module = "com.github.mthli:Slice", version = "v1.2" }
 
-# FIXME: Uncomment once SQLDelight support KMP AndroidX SQLiteDriver
-#sqlite = { module = "androidx.sqlite:sqlite-bundled", version.ref = "sqlite" }
-sqlite-ktx = { module = "androidx.sqlite:sqlite-ktx", version.ref = "sqlite" }
-sqlite-android = { module = "com.github.requery:sqlite-android", version = "3.49.0" }
+# SQLite interface
+sqlite = { module = "androidx.sqlite:sqlite", version.ref = "androidxSqlite" }
+sqlite-bundled = { module = "androidx.sqlite:sqlite-bundled", version.ref = "androidxSqlite" }
 
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
-sqldelight-android-driver = { module = "app.cash.sqldelight:android-driver", version.ref = "sqldelight" }
+sqldelight-androidx-driver = { module = "com.eygraber:sqldelight-androidx-driver", version = "0.0.12" }
 sqldelight-android-paging = { module = "app.cash.sqldelight:androidx-paging3-extensions", version.ref = "sqldelight" }
 sqldelight-dialects-sql = { module = "app.cash.sqldelight:sqlite-3-38-dialect", version.ref = "sqldelight" }
 
@@ -114,13 +113,11 @@ moko = { id = "dev.icerock.mobile.multiplatform-resources", version.ref = "moko"
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
 
 [bundles]
-db = [ "sqldelight-coroutines" ]
-db-android = [ "sqldelight-android-driver", "sqldelight-android-paging" ]
+db = [ "sqldelight-coroutines", "sqldelight-androidx-driver" ]
+db-android = [ "sqldelight-android-paging" ]
 coil = [ "coil3", "coil3-svg", "coil3-gif", "coil3-okhttp" ]
 logging = [ "kermit" ]
-# FIXME: Uncomment once SQLDelight support KMP AndroidX SQLiteDriver
-#sqlite = [ "sqlite", "sqlite-ktx" ]
-sqlite = [ "sqlite-ktx" ]
+sqlite = [ "sqlite", "sqlite-bundled" ]
 test = [ "junit-api", "kotest-assertions", "mockk" ]
 test-android = [ "junit-android" ]
 test-runtime = [ "junit-engine" ]


### PR DESCRIPTION
Will merge this later once `AndroidxSqliteDriver` become a lot more stable


<!--
^ Please summarise the changes you have made here ^
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
