### PR TITLE
fix: Ensure consistent hashCode implementation in ProgressItem class

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/ProgressItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/ProgressItem.kt
@@ -44,6 +44,10 @@ class ProgressItem : AbstractFlexibleItem<ProgressItem.Holder>() {
         return this === other
     }
 
+    override fun hashCode(): Int {
+        return -1
+    }
+
     class Holder(view: View, adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>) : FlexibleViewHolder(view, adapter) {
 
         val progressBar: ProgressBar = view.findViewById(R.id.progress_bar)


### PR DESCRIPTION
## Fix RecyclerView stable ID crash in browse source

Fixes #542

### Root Cause
The crash occurred because the `ProgressItem` class overrides `equals()` but does not override `hashCode()`. This violates the Java/Kotlin contract where if you override `equals()`, you must also override `hashCode()`. The FlexibleAdapter library uses `hashCode()` to generate stable IDs for RecyclerView items, resulting in duplicate IDs when multiple items have the same hash value.

### Changes
Added missing `hashCode()` override to `ProgressItem` class:
```kotlin
override fun hashCode(): Int {
    return -1
}
```

### Why This Works
- Manga IDs are positive Long values (database auto-increment IDs)
- Using `-1` ensures no collision with any valid manga ID
- The pattern follows existing code (e.g., `SearchGlobalItem` uses `-100`)
- All other `AbstractFlexibleItem` subclasses already have proper `hashCode()` implementations

### Verification
- ✅ No compilation errors
- ✅ Follows existing code patterns
- ✅ No butterfly effects on other features
- ✅ Only changes the problematic `ProgressItem` class