### PR TITLE
fix(Downloader): paused download notifications not shown

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/DownloadNotifier.kt
@@ -66,6 +66,14 @@ internal class DownloadNotifier(private val context: Context) {
      */
     fun dismiss() {
         context.notificationManager.cancel(Notifications.ID_DOWNLOAD_CHAPTER)
+        context.notificationManager.cancel(Notifications.ID_DOWNLOAD_PAUSED)
+    }
+
+    /**
+     * Dismiss only the paused notification.
+     */
+    fun dismissPaused() {
+        context.notificationManager.cancel(Notifications.ID_DOWNLOAD_PAUSED)
     }
 
     fun setPlaceholder(download: Download?): NotificationCompat.Builder {
@@ -189,7 +197,7 @@ internal class DownloadNotifier(private val context: Context) {
                 context.getString(MR.strings.cancel_all),
                 NotificationReceiver.clearDownloadsPendingBroadcast(context),
             )
-            show()
+            show(Notifications.ID_DOWNLOAD_PAUSED)
         }
 
         // Reset initial values

--- a/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/download/Downloader.kt
@@ -135,6 +135,7 @@ class Downloader(
         pending.forEach { if (it.status != Download.State.QUEUE) it.status = Download.State.QUEUE }
 
         isPaused = false
+        notifier.dismissPaused()
 
         launchDownloaderJob()
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/notification/Notifications.kt
@@ -38,6 +38,7 @@ object Notifications {
     const val ID_DOWNLOAD_CHAPTER = -201
     const val ID_DOWNLOAD_CHAPTER_ERROR = -202
     const val ID_DOWNLOAD_SIZE_WARNING = -203
+    const val ID_DOWNLOAD_PAUSED = -204
 
     /**
      * Notification channel and ids used by the library updater.


### PR DESCRIPTION
<!--
^ Please summarise the changes you have made here ^
-->
- Introduced a new method `dismissPaused()` in `DownloadNotifier` to specifically handle paused download notifications.
- Updated the `Downloader` class to call `dismissPaused()` when resuming downloads, ensuring a cleaner notification experience.
- Added a new notification ID for paused downloads in the `Notifications` object.
---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
