### PR TITLE
feat(local): Merge storage locations, fix covers and global update

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/App.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/App.kt
@@ -283,7 +283,6 @@ open class App : Application(), DefaultLifecycleObserver, SingletonImageLoader.F
         return ImageLoader.Builder(this@App).apply {
             val callFactoryLazy = lazy { Injekt.get<NetworkHelper>().client }
             components {
-                // --- NEW: Add Support for APNG, GIF, and Animated WebP ---
                 // Android 9 (P) and above has native support for these via ImageDecoder
                 if (Build.VERSION.SDK_INT >= 28) {
                     add(AnimatedImageDecoder.Factory())

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -260,10 +260,10 @@ class LocalSource(private val context: Context) : CatalogueSource, UnmeteredSour
                 val rt = manga.copy().apply {
                     setMangaDetailsFromLegacyJsonFile(legacyJsonFile.openInputStream(), this)
                 }
-                
+
                 // Try to find parent of legacy json to write the new info to
                 val legacyParent = mangaDirs.firstOrNull { it.findFile(legacyJsonFile.name) != null }
-                
+
                 if (legacyParent != null) {
                     val comicInfo = rt.toComicInfo()
                     legacyParent.createFile(COMIC_INFO_FILE)
@@ -336,7 +336,7 @@ class LocalSource(private val context: Context) : CatalogueSource, UnmeteredSour
 
     override suspend fun getChapterList(manga: SManga): List<SChapter> = withIOContext {
         val dirs = getMangaDirs(context, manga.url).toList()
-        
+
         // 1. Gather files from ALL directories
         // 2. Distinct by name to merge duplicates (prioritizing based on directory order in base dirs)
         val validFiles = dirs.asSequence()
@@ -392,7 +392,7 @@ class LocalSource(private val context: Context) : CatalogueSource, UnmeteredSour
 
     fun getFormat(chapter: SChapter): Format {
         val (mangaDirName, chapterName) = chapter.url.split('/', limit = 2)
-        
+
         // Modified to look for the chapter file in any storage location
         val chapFile = getMangaDirs(context, mangaDirName)
             .mapNotNull { it.findFile(chapterName) }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -499,12 +499,10 @@ class MangaDetailsPresenter(
 
     /** Refresh Manga Info and Chapter List (not tracking) */
     fun refreshAll() {
-        // Fix: Don't block refresh if the manga is Local, even if offline
         val isLocal by lazy { manga.isLocal() }
         if (view?.isNotOnline() == true && !isLocal) return
 
         presenterScope.launch {
-            // ... (rest of the code stays same)
             isLoading = true
             val tasks = listOf(
                 async { fetchMangaFromSource() },


### PR DESCRIPTION
### Description
This PR improves the Local Source experience by fixing storage merging, scoped storage access, update reliability, and file format support. 
**Resolves #197, #270, #468, #359, #473.**

**Core Changes:**
1.  **Merged Storage (#197):** `LocalSource` now merges chapter lists from all configured storage roots (Internal + SD Card) into a single manga entry.
2.  **Reliable Covers (#270):** Fixed `cover.jpg` detection in scoped storage (`Android/data`).
3.  **Global Update Fixes (#468, #359):** 
    *   Manual Updates now correctly process `LocalSource` entries.
    *   **Automatic Updates** now *strictly ignore* `LocalSource` entries to prevent data loss if files are temporarily moved/unmounted.
4.  **APNG & Animation Support (#473):** registered `AnimatedImageDecoder` (Coil) in `App.kt`. This enables support for APNG, Animated WebP, and GIFs (fixing "static image" bugs) on Android 9+.

### Technical Details
*   **App.kt:** Added `AnimatedImageDecoder.Factory` (API 28+) / `GifDecoder.Factory` to `newImageLoader` components.
*   **LibraryUpdateJob.kt:** 
    *   Filter: Excludes local manga if `WORK_NAME_AUTO` tag is present.
    *   Processing: Allows `CatalogueSource` types.
*   **LocalSource.kt:** Full refactor for `UniFile` based merging logic.
*   **TachiyomiImageDecoder.kt:** Preserved existing JXL/AVIF handling alongside new animation support.

### Checklist
- [x] Tested manually
- [x] Code follows project style

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
