### PR TITLE
fix: prevent FAB from overlapping navigation bar

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
@@ -35,11 +35,13 @@ import androidx.appcompat.widget.SearchView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.graphics.ColorUtils
 import androidx.core.net.toFile
+import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsCompat.Type.systemBars
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePaddingRelative
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.palette.graphics.Palette
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -245,6 +247,17 @@ class MangaDetailsController :
 
         setTabletMode(view)
         setRecycler(view)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.fab) { view, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+
+            view.updateLayoutParams {
+                if (this is CoordinatorLayout.LayoutParams) {
+                    bottomMargin = systemBars.bottom + 16.dpToPx
+                }
+            }
+
+            insets
+        }
         setPaletteColor()
         adapter?.fastScroller = binding.fastScroller
         binding.fastScroller.addOnScrollStateChangeListener {

--- a/app/src/main/res/layout/manga_details_controller.xml
+++ b/app/src/main/res/layout/manga_details_controller.xml
@@ -84,6 +84,8 @@
         android:text="@string/read"
         android:visibility="gone"
         app:icon="@drawable/ic_play_arrow_24dp"
+        android:layout_gravity="bottom|end"
+        android:layout_marginEnd="16dp"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 


### PR DESCRIPTION
<!--
^ Please summarise the changes you have made here ^
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
