### PR TITLE
Fix locale index calculation for language selection

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/controllers/SettingsGeneralController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/controllers/SettingsGeneralController.kt
@@ -197,7 +197,7 @@ class SettingsGeneralController : SettingsLegacyController() {
 
                     val locale = AppCompatDelegate.getApplicationLocales().get(0)?.toLanguageTag()
                     if (locale != null) {
-                        langs.find { it.tag == locale }?.let { tempValue = langs.indexOf(it) + 1 }
+                        langs.find { it.tag == locale }?.let { tempValue = langs.indexOf(it) }
                     }
 
                     onChange {


### PR DESCRIPTION
Fixes the error of displaying a language different from the selected one
<!--
^ Please summarise the changes you have made here ^
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
