### PR TITLE
refactor(strings): improve noun/verb distinction for Filter and Read

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
@@ -899,7 +899,7 @@ class MangaDetailsController :
                 if (nextChapter.last_page_read > 0) {
                     MR.strings.resume
                 } else {
-                    MR.strings.read
+                    MR.strings.start_reading
                 },
             )
         } else {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/settings/TabbedReaderSettingsSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/settings/TabbedReaderSettingsSheet.kt
@@ -67,7 +67,7 @@ class TabbedReaderSettingsSheet(
     override fun getTabTitles(): List<StringResource> = listOf(
         MR.strings.general,
         if (showWebtoonView) MR.strings.long_strip else MR.strings.paged,
-        MR.strings.filter,
+        MR.strings.custom_filter,
     )
 
     init {

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -429,6 +429,7 @@
     <string name="use_custom_brightness">Use custom brightness</string>
     <string name="grayscale">Grayscale</string>
     <string name="pref_inverted_colors">Inverted</string>
+    <string name="custom_filter">Filters</string>
     <string name="use_custom_color_filter">Use custom color filter</string>
     <string name="color_filter_blend_mode">Color filter blend mode</string>
     <string name="overlay">Overlay</string>


### PR DESCRIPTION
Some languages require different translations for noun and verb forms.
Added a context-specific string and updated relevant usages accordingly.
<!--
^ Please summarise the changes you have made here ^
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
