### PR TITLE
fix(LocalSource): Prevent forced auto-refresh when opening entries (#…

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -222,8 +222,8 @@ class MangaDetailsPresenter(
             .onEach { onUpdateManga() }
             .launchIn(presenterScope)
 
-        val fetchMangaNeeded = !manga.initialized || manga.isLocal()
-        val fetchChaptersNeeded = runBlocking { getChaptersNow() }.isEmpty() || manga.isLocal()
+        val fetchMangaNeeded = !manga.initialized
+        val fetchChaptersNeeded = runBlocking { getChaptersNow() }.isEmpty()
 
         presenterScope.launch {
             isLoading = true


### PR DESCRIPTION
### Description
This fixes #359 by disabling the forced, immediate background fetch of `LocalSource` entries when viewing manga details.

**The Issue:**
Currently, `MangaDetailsPresenter` forcibly queries and overwrites local data on instantiation. If a user was mid-editing or temporarily adjusting/moving local cbz/zip archives through a file manager while the Yokai UI refreshed the manga instance, active reading data and user state can drop. 

**The Fix:**
Removed the fallback `|| manga.isLocal()` fetch triggers inside `onCreateLate`. Local entry updates are now completely respected statically on detail viewing unless deliberately triggered through the `Pull-to-Refresh` library or detail UI hooks natively.

### Checklist
- [x] Tested manually
- [x] Addressed logic regression (#359)

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
