### PR TITLE
feat(ui): migrate progress indicators to LoadingIndicator (Material 3)

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/ProgressItem.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/source/browse/ProgressItem.kt
@@ -1,9 +1,9 @@
 package eu.kanade.tachiyomi.ui.source.browse
 
 import android.view.View
-import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.loadingindicator.LoadingIndicator
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.davidea.flexibleadapter.items.AbstractFlexibleItem
 import eu.davidea.flexibleadapter.items.IFlexible
@@ -50,7 +50,7 @@ class ProgressItem : AbstractFlexibleItem<ProgressItem.Holder>() {
 
     class Holder(view: View, adapter: FlexibleAdapter<IFlexible<RecyclerView.ViewHolder>>) : FlexibleViewHolder(view, adapter) {
 
-        val progressBar: ProgressBar = view.findViewById(R.id.progress_bar)
+        val progressBar: LoadingIndicator = view.findViewById(R.id.progress_bar)
         val progressMessage: TextView = view.findViewById(R.id.progress_message)
     }
 }

--- a/app/src/main/res/layout/browse_source_controller.xml
+++ b/app/src/main/res/layout/browse_source_controller.xml
@@ -15,14 +15,15 @@
         android:id="@+id/catalogue_view"
         tools:context="eu.kanade.tachiyomi.ui.source.browse.BrowseSourceController">
 
-        <com.google.android.material.progressindicator.CircularProgressIndicator
+        <com.google.android.material.loadingindicator.LoadingIndicator
             android:id="@+id/progress"
             android:indeterminate="true"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical|center_horizontal"
             android:visibility="gone"
-            tools:visibility="visible"/>
+            tools:visibility="visible"
+            app:indicatorSize="100dp"/>
 
     </FrameLayout>
 

--- a/app/src/main/res/layout/library_controller.xml
+++ b/app/src/main/res/layout/library_controller.xml
@@ -8,7 +8,7 @@
     android:clipChildren="false"
     android:layout_height="match_parent">
 
-    <com.google.android.material.progressindicator.CircularProgressIndicator
+    <com.google.android.material.loadingindicator.LoadingIndicator
         android:id="@+id/progress"
         android:indeterminate="true"
         android:layout_width="75dp"

--- a/app/src/main/res/layout/reader_activity.xml
+++ b/app/src/main/res/layout/reader_activity.xml
@@ -14,7 +14,7 @@
         android:layout_height="match_parent"
         android:descendantFocusability="blocksDescendants" />
 
-    <com.google.android.material.progressindicator.CircularProgressIndicator
+    <com.google.android.material.loadingindicator.LoadingIndicator
         android:id="@+id/please_wait"
         android:layout_width="56dp"
         android:layout_height="56dp"

--- a/app/src/main/res/layout/recents_controller.xml
+++ b/app/src/main/res/layout/recents_controller.xml
@@ -6,7 +6,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <com.google.android.material.progressindicator.CircularProgressIndicator
+    <com.google.android.material.loadingindicator.LoadingIndicator
         android:id="@+id/progress"
         android:indeterminate="true"
         android:layout_width="75dp"

--- a/app/src/main/res/layout/source_progress_item.xml
+++ b/app/src/main/res/layout/source_progress_item.xml
@@ -4,11 +4,13 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:padding="8dp">
 
-    <com.google.android.material.progressindicator.CircularProgressIndicator
+    <com.google.android.material.loadingindicator.LoadingIndicator
         android:id="@+id/progress_bar"
         android:indeterminate="true"
+        app:indicatorSize="24dp"
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_gravity="center"/>


### PR DESCRIPTION
Replaces CircularProgressIndicator with LoadingIndicator across the app.

- Aligns with newer Material 3 components


<!--
^ Please summarise the changes you have made here ^
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
