### PR TITLE
fix: Universal cover URIs, isolated markdown parsing, and category sh…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Add toggle to enable/disable hide source on swipe (@Hiirbaf)
 - Add the ability to mark duplicate read chapters as read (@AntsyLich)
 - Add option to zoom into full covers (@Hiirbaf)
-- Add APNG support for Android 9+ (@lalalasupa0)
+- Add Animated WebP and GIF support for Android 9+ (@lalalasupa0)
 - Add markdown support to entry description (@luigidotmoe)
   - Fix text disappeared when it's surrounded by `<>` (@lalalasupa0)
 

--- a/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/source/LocalSource.kt
@@ -95,7 +95,7 @@ class LocalSource(private val context: Context) : CatalogueSource, UnmeteredSour
                 .mapNotNull { getCoverFile(it) }
                 .firstOrNull() ?: return
 
-            manga.thumbnail_url = cover.uri.toString()
+            manga.thumbnail_url = cover.filePath?.let { "file://$it" } ?: cover.uri.toString()
         }
 
         fun updateCover(manga: SManga, input: InputStream, context: Context = Injekt.get<Application>()): UniFile? {
@@ -116,7 +116,7 @@ class LocalSource(private val context: Context) : CatalogueSource, UnmeteredSour
                     input.copyTo(it)
                 }
             }
-            manga.thumbnail_url = cover.uri.toString()
+            manga.thumbnail_url = cover.filePath?.let { "file://$it" } ?: cover.uri.toString()
             return cover
         }
 
@@ -219,7 +219,7 @@ class LocalSource(private val context: Context) : CatalogueSource, UnmeteredSour
                     // Try to find the cover
                     val cover = getCoverFile(mangaDir)
                     if (cover != null && cover.exists()) {
-                        thumbnail_url = cover.uri.toString()
+                        thumbnail_url = cover.filePath?.let { "file://$it" } ?: cover.uri.toString()
                     }
                 }
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/category/addtolibrary/SetCategoriesSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/category/addtolibrary/SetCategoriesSheet.kt
@@ -220,6 +220,7 @@ class SetCategoriesSheet(
         binding.root.post {
             binding.categoryRecyclerView.scrollToPosition(
                 max(0, itemAdapter.adapterItems.indexOf(selectedItems.firstOrNull())),
+                updateBottomButtons()
             )
         }
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaHeaderHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaHeaderHolder.kt
@@ -273,7 +273,7 @@ class MangaHeaderHolder(
 
     private fun setDescription() {
         if (binding != null) {
-            val desc = adapter.controller.mangaPresenter().manga.description?.replace("<", "&lt;")?.replace(">", "&gt;")?.replace(Regex("""(?m)^\s*-\s*$"""), "\\-")?.replace(Regex("""(?m)^\s*\*\s*$"""), "\\*")
+            val desc = adapter.controller.mangaPresenter().manga.description?.replace(Regex("<(?!!--)"), "&lt;")?.replace(Regex("(?m)^\s*([-*])\s*$"), "\u200C$1")
             binding.mangaSummary.movementMethod = LinkMovementMethod.getInstance()
             binding.mangaSummary.text = when {
                 desc.isNullOrBlank() -> itemView.context.getString(MR.strings.no_description)


### PR DESCRIPTION
### Description
This PR cleans up a few minor regressions and UI/UX formatting anomalies introduced in recent system changes:

1. **Local Source Cover Resolution:** Bypassing native URI generation previously broke standard `file://` scheme attachments for Coil 3 on Primary Storage directories containing spaces, causing `ENOENT` silent failures. Prepending the scheme manually to `filePath` restores encoding compatibility across both Scoped and Primary directories without URL-encoding traps
~~2. **Category Sheet UI Dissipation (#128):** Re-added `updateBottomButtons()` translation math inside `SetCategoriesSheet.kt`. The dynamic `translationY` math bounds the Cancel/Move buttons safely above the navigation bar, preventing them from sliding completely off-screen on devices with dense lists~~ (?)
3. **Markdown Formatting Anomalies:** Added dynamic text replacements in `MangaHeaderHolder` to convert `<` into `&lt;` while utilizing negative lookaheads `(?!!--)` to preserve HTML comment invisibility (`<!-- -->`). This stops `Markwon` from interpreting E-Hentai tags as invisible HTML nodes. Also added a zero-width non-joiner (`\u200C`) escape for lone hyphens (`-`) and asterisks (`*`) to prevent single dashes from being swallowed as empty unordered list items

### Checklist
- [x] Code follows project style

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
