### PR TITLE
Add two-way chapter progress sync with tracker auto-sync

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -327,7 +327,7 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
                         val newTrack = service.refresh(track)
                         insertTrack.await(newTrack)
 
-                        syncChaptersWithTrackServiceTwoWay(getChapter.awaitAll(manga.manga.id!!, false), track, service)
+                        syncChaptersWithTrackServiceTwoWay(getChapter.awaitAll(manga.manga.id!!, false), newTrack, service)
                     } catch (e: Exception) {
                         Logger.e(e)
                     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/preference/PreferenceKeys.kt
@@ -91,6 +91,8 @@ object PreferenceKeys {
 
     const val trackMarkedAsRead = "track_marked_as_read"
 
+    const val autoSyncProgressFromTrackers = "pref_auto_sync_progress_from_trackers_key"
+
     const val trackingsToAddOnline = "pref_tracking_for_online"
 
     const val lastUsedCatalogueSource = "last_catalogue_source"

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackPreferences.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackPreferences.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.data.track
 
 import eu.kanade.tachiyomi.core.preference.Preference
 import eu.kanade.tachiyomi.core.preference.PreferenceStore
+import eu.kanade.tachiyomi.data.preference.PreferenceKeys
 import eu.kanade.tachiyomi.data.track.anilist.Anilist
 
 class TrackPreferences(
@@ -28,6 +29,8 @@ class TrackPreferences(
     fun anilistScoreType() = preferenceStore.getString("anilist_score_type", Anilist.POINT_10)
 
     fun autoUpdateTrack() = preferenceStore.getBoolean("pref_auto_update_manga_sync_key", true)
+
+    fun autoSyncProgressFromTrackers() = preferenceStore.getBoolean(PreferenceKeys.autoSyncProgressFromTrackers, true)
 
     companion object {
         fun trackUsername(syncId: Long) = Preference.privateKey("pref_mangasync_username_$syncId")

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackService.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/TrackService.kt
@@ -47,6 +47,8 @@ abstract class TrackService(val id: Long) {
     abstract fun readingStatus(): Int
     abstract fun planningStatus(): Int
 
+    open fun hasNotStartedReading(status: Int): Boolean = status == planningStatus()
+
     abstract fun getStatus(status: Int): String
 
     abstract fun getGlobalStatus(status: Int): String

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
@@ -887,6 +887,7 @@ class MangaDetailsController :
         adapter?.setChapters(presenter.chapters)
         tabletAdapter?.notifyItemChanged(0)
         addMangaHeader()
+        rebindVisibleHeader()
         updateMenuVisibility(activityBinding?.toolbar?.menu)
     }
 
@@ -913,6 +914,7 @@ class MangaDetailsController :
         tabletAdapter?.notifyItemChanged(0)
         adapter?.setChapters(presenter.chapters)
         addMangaHeader()
+        rebindVisibleHeader()
         updateFab()
         colorToolbar(binding.recycler.canScrollVertically(-1))
         updateMenuVisibility(activityBinding?.toolbar?.menu)
@@ -929,6 +931,10 @@ class MangaDetailsController :
             adapter?.removeAllScrollableHeaders()
             adapter?.addScrollableHeader(presenter.headerItem)
         }
+    }
+
+    private fun rebindVisibleHeader() {
+        getHeader()?.bind(presenter.headerItem)
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -108,6 +108,8 @@ import yokai.domain.track.interactor.GetTrack
 import yokai.domain.track.interactor.InsertTrack
 import yokai.i18n.MR
 import yokai.util.lang.getString
+import java.text.DecimalFormat
+import java.text.DecimalFormatSymbols
 
 class MangaDetailsPresenter(
     val mangaId: Long,
@@ -132,6 +134,10 @@ class MangaDetailsPresenter(
     private val trackPreferences: TrackPreferences by injectLazy()
 
     private val networkPreferences: NetworkPreferences by injectLazy()
+    private val chapterFormat = DecimalFormat(
+        "#.###",
+        DecimalFormatSymbols().apply { decimalSeparator = '.' },
+    )
 
 //    private val currentMangaInternal: MutableStateFlow<Manga?> = MutableStateFlow(null)
 //    val currentManga get() = currentMangaInternal.asStateFlow()
@@ -241,14 +247,18 @@ class MangaDetailsPresenter(
             )
             tasks.awaitAll()
             isLoading = false
+            setTrackItems()
+            if (trackPreferences.autoSyncProgressFromTrackers().get()) {
+                refreshTracksAndSync(
+                    items = trackList.filter { it.track != null },
+                    showSyncToast = false,
+                )
+            }
+            fetchTracks()
             withUIContext {
                 controller.updateChapters()
             }
-
-            setTrackItems()
         }
-
-        refreshTracking(false)
     }
 
     fun fetchChapters(andTracking: Boolean = true) {
@@ -1010,10 +1020,20 @@ class MangaDetailsPresenter(
             refreshedChapters.filterNotNull().maxOrNull()
         }
 
-        if (showSyncToast) {
-            syncedChapter?.let {
+        syncedChapter?.let {
+            getChapters()
+            withUIContext {
+                view?.updateChapters()
+            }
+
+            if (showSyncToast) {
                 withUIContext {
-                    view?.activity?.toast(MR.strings.sync_progress_from_trackers_up_to_chapter, it)
+                    view?.activity?.toast(
+                        view?.activity?.getString(
+                            MR.strings.sync_progress_from_trackers_up_to_chapter,
+                            formatSyncedChapter(it.toFloat()),
+                        ),
+                    )
                 }
             }
         }
@@ -1050,24 +1070,42 @@ class MangaDetailsPresenter(
             item.manga_id = manga.id!!
 
             presenterScope.launch {
-                val binding = try {
+                val refreshedTrack = try {
                     service.bind(item)
+                        .let { service.refresh(it) }
                 } catch (e: Exception) {
                     trackError(e)
                     null
                 }
                 withContext(Dispatchers.IO) {
-                    if (binding != null) {
-                        insertTrack.await(binding)
-                        syncChaptersWithTrackServiceTwoWay(allDbChapters(), binding, service)?.let {
+                    if (refreshedTrack != null) {
+                        insertTrack.await(refreshedTrack)
+                        syncChaptersWithTrackServiceTwoWay(allDbChapters(), refreshedTrack, service)?.let {
+                            getChapters()
                             withUIContext {
-                                view?.activity?.toast(MR.strings.sync_progress_from_trackers_up_to_chapter, it)
+                                view?.updateChapters()
+                            }
+                            withUIContext {
+                                view?.activity?.toast(
+                                    view?.activity?.getString(
+                                        MR.strings.sync_progress_from_trackers_up_to_chapter,
+                                        formatSyncedChapter(it.toFloat()),
+                                    ),
+                                )
                             }
                         }
                     }
                 }
                 fetchTracks()
             }
+        }
+    }
+
+    private fun formatSyncedChapter(chapter: Float): String {
+        return if (chapter % 1f == 0f) {
+            chapter.toInt().toString()
+        } else {
+            chapterFormat.format(chapter.toDouble())
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -32,6 +32,7 @@ import eu.kanade.tachiyomi.data.library.LibraryUpdateJob
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.track.EnhancedTrackService
 import eu.kanade.tachiyomi.data.track.TrackManager
+import eu.kanade.tachiyomi.data.track.TrackPreferences
 import eu.kanade.tachiyomi.data.track.TrackService
 import eu.kanade.tachiyomi.domain.manga.models.Manga
 import eu.kanade.tachiyomi.network.HttpException
@@ -66,6 +67,7 @@ import eu.kanade.tachiyomi.util.system.launchIO
 import eu.kanade.tachiyomi.util.system.launchNonCancellableIO
 import eu.kanade.tachiyomi.util.system.launchNow
 import eu.kanade.tachiyomi.util.system.launchUI
+import eu.kanade.tachiyomi.util.system.toast
 import eu.kanade.tachiyomi.util.system.withIOContext
 import eu.kanade.tachiyomi.util.system.withUIContext
 import eu.kanade.tachiyomi.widget.TriStateCheckBox
@@ -74,9 +76,11 @@ import java.io.FileOutputStream
 import java.io.OutputStream
 import java.util.Locale
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
@@ -125,6 +129,7 @@ class MangaDetailsPresenter(
     private val getTrack: GetTrack by injectLazy()
     private val insertTrack: InsertTrack by injectLazy()
     private val getHistory: GetHistory by injectLazy()
+    private val trackPreferences: TrackPreferences by injectLazy()
 
     private val networkPreferences: NetworkPreferences by injectLazy()
 
@@ -323,6 +328,8 @@ class MangaDetailsPresenter(
         return model
     }
 
+    private fun allDbChapters(): List<Chapter> = allChapters.map { it.chapter }
+
     /**
      * Whether the sorting method is descending or ascending.
      */
@@ -504,11 +511,24 @@ class MangaDetailsPresenter(
 
         presenterScope.launch {
             isLoading = true
+            val autoSyncTrackers = trackPreferences.autoSyncProgressFromTrackers().get()
+            val canRefreshTrackers = autoSyncTrackers && (view?.isNotOnline() != true || !isLocal)
             val tasks = listOf(
+                async {
+                    if (canRefreshTrackers) {
+                        refreshTracksAndSync(
+                            items = trackList.filter { it.track != null },
+                            showSyncToast = true,
+                        )
+                    }
+                },
                 async { fetchMangaFromSource() },
                 async { fetchChaptersFromSource() },
             )
             tasks.awaitAll()
+            if (canRefreshTrackers) {
+                fetchTracks()
+            }
             isLoading = false
             withUIContext {
                 view?.updateChapters()
@@ -969,28 +989,43 @@ class MangaDetailsPresenter(
         withContext(Dispatchers.Main) { view?.refreshTracking(trackList) }
     }
 
+    private suspend fun refreshTracksAndSync(
+        items: List<TrackItem>,
+        showSyncToast: Boolean,
+    ) {
+        val syncedChapter: Int? = coroutineScope {
+            val refreshJobs: List<Deferred<Int?>> = items.map { item ->
+                async<Int?>(Dispatchers.IO) {
+                    try {
+                        val refreshedTrack = item.service.refresh(item.track!!)
+                        insertTrack.await(refreshedTrack)
+                        syncChaptersWithTrackServiceTwoWay(allDbChapters(), refreshedTrack, item.service)
+                    } catch (e: Exception) {
+                        trackError(e)
+                        null
+                    }
+                }
+            }
+            val refreshedChapters: List<Int?> = refreshJobs.awaitAll()
+            refreshedChapters.filterNotNull().maxOrNull()
+        }
+
+        if (showSyncToast) {
+            syncedChapter?.let {
+                withUIContext {
+                    view?.activity?.toast(MR.strings.sync_progress_from_trackers_up_to_chapter, it)
+                }
+            }
+        }
+    }
+
     fun refreshTracking(showOfflineSnack: Boolean = false, trackIndex: Int? = null) {
         if (view?.isNotOnline(showOfflineSnack) == false) {
             presenterScope.launch {
-                val asyncList = (trackIndex?.let { listOf(trackList[it]) } ?: trackList.filter { it.track != null })
-                    .map { item ->
-                        async(Dispatchers.IO) {
-                            val trackItem = try {
-                                item.service.refresh(item.track!!)
-                            } catch (e: Exception) {
-                                trackError(e)
-                                null
-                            }
-                            if (trackItem != null) {
-                                insertTrack.await(trackItem)
-                                syncChaptersWithTrackServiceTwoWay(chapters, trackItem, item.service)
-                                trackItem
-                            } else {
-                                item.track
-                            }
-                        }
-                    }
-                asyncList.awaitAll()
+                refreshTracksAndSync(
+                    items = trackIndex?.let { listOf(trackList[it]) } ?: trackList.filter { it.track != null },
+                    showSyncToast = true,
+                )
                 fetchTracks()
             }
         }
@@ -1024,9 +1059,12 @@ class MangaDetailsPresenter(
                 withContext(Dispatchers.IO) {
                     if (binding != null) {
                         insertTrack.await(binding)
+                        syncChaptersWithTrackServiceTwoWay(allDbChapters(), binding, service)?.let {
+                            withUIContext {
+                                view?.activity?.toast(MR.strings.sync_progress_from_trackers_up_to_chapter, it)
+                            }
+                        }
                     }
-
-                    syncChaptersWithTrackServiceTwoWay(chapters, item, service)
                 }
                 fetchTracks()
             }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/setting/controllers/SettingsTrackingController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/setting/controllers/SettingsTrackingController.kt
@@ -59,6 +59,11 @@ class SettingsTrackingController :
             titleRes = MR.strings.update_tracking_marked_read
             defaultValue = false
         }
+        switchPreference {
+            key = Keys.autoSyncProgressFromTrackers
+            titleRes = MR.strings.pref_auto_sync_progress_from_trackers
+            defaultValue = true
+        }
         preferenceCategory {
             titleRes = MR.strings.services
 

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt
@@ -5,7 +5,6 @@ import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.preference.PreferencesHelper
 import eu.kanade.tachiyomi.data.track.DelayedTrackingUpdateJob
-import eu.kanade.tachiyomi.data.track.EnhancedTrackService
 import eu.kanade.tachiyomi.data.track.TrackManager
 import eu.kanade.tachiyomi.data.track.TrackService
 import eu.kanade.tachiyomi.util.system.isOnline
@@ -19,6 +18,7 @@ import uy.kohesive.injekt.api.get
 import yokai.domain.chapter.interactor.UpdateChapter
 import yokai.domain.track.interactor.GetTrack
 import yokai.domain.track.interactor.InsertTrack
+import kotlin.math.max
 
 /**
  * Helper method for syncing a remote track with the local chapters, and back
@@ -33,30 +33,69 @@ suspend fun syncChaptersWithTrackServiceTwoWay(
     remoteTrack: Track,
     service: TrackService,
     updateChapter: UpdateChapter = Injekt.get(),
-    insertTrack: InsertTrack = Injekt.get()
-) = withIOContext {
-    if (service !is EnhancedTrackService) {
-        return@withIOContext
-    }
-
-    val sortedChapters = chapters.sortedBy { it.chapter_number }
-    sortedChapters
-        .filter { chapter -> chapter.chapter_number <= remoteTrack.last_chapter_read && !chapter.read }
-        .forEach { it.read = true }
-    updateChapter.awaitAll(sortedChapters.map(Chapter::toProgressUpdate))
-
-    // only take into account continuous reading
-    val localLastRead = sortedChapters.takeWhile { it.read }.lastOrNull()?.chapter_number ?: 0F
-
-    // update remote
-    remoteTrack.last_chapter_read = localLastRead
+    insertTrack: InsertTrack = Injekt.get(),
+): Int? = withIOContext {
+    val syncResult = calculateTwoWayTrackerSync(chapters, remoteTrack.last_chapter_read)
+    val lastRead = max(remoteTrack.last_chapter_read.toDouble(), syncResult.localLastRead.toDouble()).toFloat()
 
     try {
-        service.update(remoteTrack)
-        insertTrack.await(remoteTrack)
+        if (lastRead > remoteTrack.last_chapter_read) {
+            remoteTrack.last_chapter_read = lastRead
+            val updatedTrack = service.update(remoteTrack)
+            insertTrack.await(updatedTrack)
+        }
+
+        if (
+            syncResult.chapterUpdates.isNotEmpty() &&
+            !service.hasNotStartedReading(remoteTrack.status)
+        ) {
+            syncResult.chapterUpdates.forEach { it.read = true }
+            updateChapter.awaitAll(syncResult.chapterUpdates.map(Chapter::toProgressUpdate))
+            return@withIOContext lastRead.toInt()
+        }
     } catch (e: Throwable) {
         Logger.w(e)
     }
+
+    return@withIOContext null
+}
+
+internal data class TwoWayTrackerSyncResult(
+    val chapterUpdates: List<Chapter>,
+    val localLastRead: Float,
+)
+
+internal fun calculateTwoWayTrackerSync(
+    chapters: List<Chapter>,
+    remoteLastRead: Float,
+): TwoWayTrackerSyncResult {
+    val dbChapters = chapters
+        .filter { it.isRecognizedNumber }
+        .sortedByDescending { it.source_order }
+
+    val sortedChapters = dbChapters.sortedBy { it.chapter_number }
+
+    var lastCheckChapter = 0.0f
+    var checkingChapter = 0.0f
+
+    val chapterUpdates = dbChapters
+        .takeWhile { chapter ->
+            lastCheckChapter = checkingChapter
+            checkingChapter = chapter.chapter_number
+            chapter.chapter_number >= lastCheckChapter && chapter.chapter_number <= remoteLastRead
+        }
+        .filterNot { it.read }
+
+    val localLastRead = sortedChapters
+        .takeWhile { it.read }
+        .lastOrNull()
+        ?.chapter_number
+        ?: 0f
+
+    return TwoWayTrackerSyncResult(
+        chapterUpdates = chapterUpdates,
+        localLastRead = localLastRead,
+    )
 }
 
 private var trackingJobs = HashMap<Long, Pair<Job?, Float?>>()

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt
@@ -61,6 +61,7 @@ suspend fun syncChaptersWithTrackServiceTwoWay(
 }
 
 internal data class TwoWayTrackerSyncResult(
+    val coveredChapterNumbers: Set<Float>,
     val chapterUpdates: List<Chapter>,
     val localLastRead: Float,
 )
@@ -69,21 +70,29 @@ internal fun calculateTwoWayTrackerSync(
     chapters: List<Chapter>,
     remoteLastRead: Float,
 ): TwoWayTrackerSyncResult {
-    val dbChapters = chapters
+    val recognizedChapters = chapters
         .filter { it.isRecognizedNumber }
         .sortedByDescending { it.source_order }
 
-    val sortedChapters = dbChapters.sortedBy { it.chapter_number }
+    val sortedChapters = recognizedChapters.sortedBy { it.chapter_number }
+    val orderedUniqueChapterNumbers = recognizedChapters
+        .map { it.chapter_number }
+        .distinct()
 
     var lastCheckChapter = 0.0f
-    var checkingChapter = 0.0f
 
-    val chapterUpdates = dbChapters
-        .takeWhile { chapter ->
-            lastCheckChapter = checkingChapter
-            checkingChapter = chapter.chapter_number
-            chapter.chapter_number >= lastCheckChapter && chapter.chapter_number <= remoteLastRead
+    val coveredChapterNumbers = orderedUniqueChapterNumbers
+        .takeWhile { chapterNumber ->
+            val isCovered = chapterNumber >= lastCheckChapter && chapterNumber <= remoteLastRead
+            if (isCovered) {
+                lastCheckChapter = chapterNumber
+            }
+            isCovered
         }
+        .toSet()
+
+    val chapterUpdates = recognizedChapters
+        .filter { it.chapter_number in coveredChapterNumbers }
         .filterNot { it.read }
 
     val localLastRead = sortedChapters
@@ -93,6 +102,7 @@ internal fun calculateTwoWayTrackerSync(
         ?: 0f
 
     return TwoWayTrackerSyncResult(
+        coveredChapterNumbers = coveredChapterNumbers,
         chapterUpdates = chapterUpdates,
         localLastRead = localLastRead,
     )

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSync.kt
@@ -72,18 +72,19 @@ internal fun calculateTwoWayTrackerSync(
 ): TwoWayTrackerSyncResult {
     val recognizedChapters = chapters
         .filter { it.isRecognizedNumber }
-        .sortedByDescending { it.source_order }
+        .sortedBy { it.source_order }
 
     val sortedChapters = recognizedChapters.sortedBy { it.chapter_number }
     val orderedUniqueChapterNumbers = recognizedChapters
         .map { it.chapter_number }
         .distinct()
 
-    var lastCheckChapter = 0.0f
+    var lastCheckChapter = Float.POSITIVE_INFINITY
 
     val coveredChapterNumbers = orderedUniqueChapterNumbers
+        .dropWhile { chapterNumber -> chapterNumber > remoteLastRead }
         .takeWhile { chapterNumber ->
-            val isCovered = chapterNumber >= lastCheckChapter && chapterNumber <= remoteLastRead
+            val isCovered = chapterNumber <= lastCheckChapter
             if (isCovered) {
                 lastCheckChapter = chapterNumber
             }

--- a/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSyncTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSyncTest.kt
@@ -82,8 +82,8 @@ class ChapterTrackSyncTest {
             remoteLastRead = 3f,
         )
 
-        assertEquals(setOf(3f), result.coveredChapterNumbers)
-        assertEquals(listOf(3f), result.chapterUpdates.map { it.chapter_number })
+        assertEquals(setOf(3f, 1f), result.coveredChapterNumbers)
+        assertEquals(listOf(3f, 1f), result.chapterUpdates.map { it.chapter_number })
     }
 
     @Test

--- a/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSyncTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSyncTest.kt
@@ -17,6 +17,7 @@ class ChapterTrackSyncTest {
             remoteLastRead = 3f,
         )
 
+        assertEquals(setOf(3f, 2f, 1f), result.coveredChapterNumbers)
         assertEquals(listOf(3f, 2f, 1f), result.chapterUpdates.map { it.chapter_number })
         assertEquals(0f, result.localLastRead)
     }
@@ -34,6 +35,7 @@ class ChapterTrackSyncTest {
             remoteLastRead = 3f,
         )
 
+        assertEquals(setOf(3f, 2f, 1f), result.coveredChapterNumbers)
         assertEquals(emptyList<Float>(), result.chapterUpdates.map { it.chapter_number })
         assertEquals(5f, result.localLastRead)
     }
@@ -49,6 +51,7 @@ class ChapterTrackSyncTest {
             remoteLastRead = 3f,
         )
 
+        assertEquals(setOf(3f, 2f, 1f), result.coveredChapterNumbers)
         assertEquals(emptyList<Float>(), result.chapterUpdates.map { it.chapter_number })
         assertEquals(3f, result.localLastRead)
     }
@@ -64,6 +67,7 @@ class ChapterTrackSyncTest {
             remoteLastRead = 2f,
         )
 
+        assertEquals(setOf(2f, 1f), result.coveredChapterNumbers)
         assertEquals(listOf(2f, 1f), result.chapterUpdates.map { it.chapter_number })
     }
 
@@ -78,6 +82,7 @@ class ChapterTrackSyncTest {
             remoteLastRead = 3f,
         )
 
+        assertEquals(setOf(3f), result.coveredChapterNumbers)
         assertEquals(listOf(3f), result.chapterUpdates.map { it.chapter_number })
     }
 
@@ -93,55 +98,91 @@ class ChapterTrackSyncTest {
             remoteLastRead = 10f,
         )
 
+        assertEquals(setOf(10f, 8f, 7f), result.coveredChapterNumbers)
         assertEquals(listOf(10f, 8f, 7f), result.chapterUpdates.map { it.chapter_number })
     }
 
     @Test
-    fun `hidden chapters in filtered view would be missed by tracker sync`() {
-        val fullResult = calculateTwoWayTrackerSync(
+    fun `duplicate chapter variants are all marked when covered`() {
+        val result = calculateTwoWayTrackerSync(
             chapters = listOf(
-                chapter(number = 3f, sourceOrder = 0, read = false),
-                chapter(number = 2f, sourceOrder = 1, read = false),
-                chapter(number = 1f, sourceOrder = 2, read = false),
+                chapter(number = 165f, sourceOrder = 0, read = false, name = "Official Scans 165", url = "/official-165"),
+                chapter(number = 165f, sourceOrder = 1, read = false, name = "Punch 165", url = "/punch-165"),
+                chapter(number = 164f, sourceOrder = 2, read = false, name = "Punch 164", url = "/punch-164"),
             ),
-            remoteLastRead = 3f,
-        )
-        val filteredResult = calculateTwoWayTrackerSync(
-            chapters = listOf(
-                chapter(number = 3f, sourceOrder = 0, read = false),
-                chapter(number = 1f, sourceOrder = 2, read = false),
-            ),
-            remoteLastRead = 3f,
+            remoteLastRead = 165f,
         )
 
-        assertEquals(listOf(3f, 2f, 1f), fullResult.chapterUpdates.map { it.chapter_number })
-        assertEquals(listOf(3f, 1f), filteredResult.chapterUpdates.map { it.chapter_number })
+        assertEquals(setOf(165f, 164f), result.coveredChapterNumbers)
+        assertEquals(
+            listOf("Official Scans 165", "Punch 165", "Punch 164"),
+            result.chapterUpdates.map { it.name },
+        )
     }
 
     @Test
-    fun `filtered chapter list understates local continuous progress`() {
-        val fullResult = calculateTwoWayTrackerSync(
+    fun `interleaved one punch man style variants continue across duplicate branches`() {
+        val result = calculateTwoWayTrackerSync(
             chapters = listOf(
-                chapter(number = 4f, sourceOrder = 0, read = true),
-                chapter(number = 3f, sourceOrder = 1, read = true),
-                chapter(number = 2f, sourceOrder = 2, read = true),
-                chapter(number = 1f, sourceOrder = 3, read = true),
+                chapter(number = 167f, sourceOrder = 0, read = false, name = "Punch 167", url = "/punch-167"),
+                chapter(number = 166f, sourceOrder = 1, read = false, name = "Punch 166", url = "/punch-166"),
+                chapter(number = 165f, sourceOrder = 2, read = false, name = "Official Scans 165", url = "/official-165"),
+                chapter(number = 165f, sourceOrder = 3, read = false, name = "Punch 165", url = "/punch-165"),
+                chapter(number = 164f, sourceOrder = 4, read = false, name = "Official Scans 164", url = "/official-164"),
+                chapter(number = 164f, sourceOrder = 5, read = false, name = "Punch 164", url = "/punch-164"),
+                chapter(number = 163f, sourceOrder = 6, read = false, name = "Official Scans 163", url = "/official-163"),
+                chapter(number = 163f, sourceOrder = 7, read = false, name = "Punch 163", url = "/punch-163"),
+                chapter(number = 162f, sourceOrder = 8, read = false, name = "Official Scans 162", url = "/official-162"),
+                chapter(number = 162f, sourceOrder = 9, read = false, name = "Punch 162", url = "/punch-162"),
+                chapter(number = 161f, sourceOrder = 10, read = false, name = "Official Scans 161", url = "/official-161"),
+                chapter(number = 161f, sourceOrder = 11, read = false, name = "Punch 161", url = "/punch-161"),
             ),
-            remoteLastRead = 0f,
-        )
-        val filteredResult = calculateTwoWayTrackerSync(
-            chapters = listOf(
-                chapter(number = 4f, sourceOrder = 0, read = true),
-                chapter(number = 1f, sourceOrder = 3, read = true),
-            ),
-            remoteLastRead = 0f,
+            remoteLastRead = 167f,
         )
 
-        assertEquals(4f, fullResult.localLastRead)
-        assertEquals(1f, filteredResult.localLastRead)
+        assertEquals(setOf(167f, 166f, 165f, 164f, 163f, 162f, 161f), result.coveredChapterNumbers)
+        assertEquals(12, result.chapterUpdates.size)
     }
 
-    private fun chapter(number: Float, sourceOrder: Int, read: Boolean): Chapter {
+    @Test
+    fun `mixed variants plus mag versions continue through tracker progress`() {
+        val result = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 225f, sourceOrder = 0, read = false, name = "Mag Version 225", url = "/mag-225"),
+                chapter(number = 224.5f, sourceOrder = 1, read = false, name = "ReDraw 224.5", url = "/redraw-224-5"),
+                chapter(number = 224f, sourceOrder = 2, read = false, name = "Mag Version 224", url = "/mag-224"),
+                chapter(number = 223f, sourceOrder = 3, read = false, name = "Mag Version 223", url = "/mag-223"),
+                chapter(number = 167f, sourceOrder = 4, read = false, name = "Punch 167", url = "/punch-167"),
+                chapter(number = 166f, sourceOrder = 5, read = false, name = "Punch 166", url = "/punch-166"),
+                chapter(number = 165f, sourceOrder = 6, read = false, name = "Official Scans 165", url = "/official-165"),
+                chapter(number = 165f, sourceOrder = 7, read = false, name = "Punch 165", url = "/punch-165"),
+            ),
+            remoteLastRead = 225f,
+        )
+
+        assertEquals(setOf(225f, 224.5f, 224f, 223f, 167f, 166f, 165f), result.coveredChapterNumbers)
+        assertEquals(
+            listOf(
+                "Mag Version 225",
+                "ReDraw 224.5",
+                "Mag Version 224",
+                "Mag Version 223",
+                "Punch 167",
+                "Punch 166",
+                "Official Scans 165",
+                "Punch 165",
+            ),
+            result.chapterUpdates.map { it.name },
+        )
+    }
+
+    private fun chapter(
+        number: Float,
+        sourceOrder: Int,
+        read: Boolean,
+        name: String = "Chapter $number",
+        url: String = "/$number",
+    ): Chapter {
         return Chapter.create().apply {
             id = (sourceOrder + 1).toLong()
             manga_id = 1L
@@ -152,8 +193,8 @@ class ChapterTrackSyncTest {
             last_page_read = 0
             pages_left = 0
             date_fetch = 0L
-            name = "Chapter $number"
-            url = "/$number"
+            this.name = name
+            this.url = url
         }
     }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSyncTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/util/chapter/ChapterTrackSyncTest.kt
@@ -1,0 +1,159 @@
+package eu.kanade.tachiyomi.util.chapter
+
+import eu.kanade.tachiyomi.data.database.models.Chapter
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class ChapterTrackSyncTest {
+
+    @Test
+    fun `tracker ahead marks continuous unread chapters`() {
+        val result = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 3f, sourceOrder = 0, read = false),
+                chapter(number = 2f, sourceOrder = 1, read = false),
+                chapter(number = 1f, sourceOrder = 2, read = false),
+            ),
+            remoteLastRead = 3f,
+        )
+
+        assertEquals(listOf(3f, 2f, 1f), result.chapterUpdates.map { it.chapter_number })
+        assertEquals(0f, result.localLastRead)
+    }
+
+    @Test
+    fun `local ahead only reports local continuous progress`() {
+        val result = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 5f, sourceOrder = 0, read = true),
+                chapter(number = 4f, sourceOrder = 1, read = true),
+                chapter(number = 3f, sourceOrder = 2, read = true),
+                chapter(number = 2f, sourceOrder = 3, read = true),
+                chapter(number = 1f, sourceOrder = 4, read = true),
+            ),
+            remoteLastRead = 3f,
+        )
+
+        assertEquals(emptyList<Float>(), result.chapterUpdates.map { it.chapter_number })
+        assertEquals(5f, result.localLastRead)
+    }
+
+    @Test
+    fun `equal progress does not schedule local updates`() {
+        val result = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 3f, sourceOrder = 0, read = true),
+                chapter(number = 2f, sourceOrder = 1, read = true),
+                chapter(number = 1f, sourceOrder = 2, read = true),
+            ),
+            remoteLastRead = 3f,
+        )
+
+        assertEquals(emptyList<Float>(), result.chapterUpdates.map { it.chapter_number })
+        assertEquals(3f, result.localLastRead)
+    }
+
+    @Test
+    fun `unrecognized chapters are ignored`() {
+        val result = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 2f, sourceOrder = 0, read = false),
+                chapter(number = -1f, sourceOrder = 1, read = false),
+                chapter(number = 1f, sourceOrder = 2, read = false),
+            ),
+            remoteLastRead = 2f,
+        )
+
+        assertEquals(listOf(2f, 1f), result.chapterUpdates.map { it.chapter_number })
+    }
+
+    @Test
+    fun `non monotonic numbering stops local sync`() {
+        val result = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 3f, sourceOrder = 0, read = false),
+                chapter(number = 1f, sourceOrder = 1, read = false),
+                chapter(number = 2f, sourceOrder = 2, read = false),
+            ),
+            remoteLastRead = 3f,
+        )
+
+        assertEquals(listOf(3f), result.chapterUpdates.map { it.chapter_number })
+    }
+
+    @Test
+    fun `gap after regression is not synced`() {
+        val result = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 10f, sourceOrder = 0, read = false),
+                chapter(number = 8f, sourceOrder = 1, read = false),
+                chapter(number = 7f, sourceOrder = 2, read = false),
+                chapter(number = 9f, sourceOrder = 3, read = false),
+            ),
+            remoteLastRead = 10f,
+        )
+
+        assertEquals(listOf(10f, 8f, 7f), result.chapterUpdates.map { it.chapter_number })
+    }
+
+    @Test
+    fun `hidden chapters in filtered view would be missed by tracker sync`() {
+        val fullResult = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 3f, sourceOrder = 0, read = false),
+                chapter(number = 2f, sourceOrder = 1, read = false),
+                chapter(number = 1f, sourceOrder = 2, read = false),
+            ),
+            remoteLastRead = 3f,
+        )
+        val filteredResult = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 3f, sourceOrder = 0, read = false),
+                chapter(number = 1f, sourceOrder = 2, read = false),
+            ),
+            remoteLastRead = 3f,
+        )
+
+        assertEquals(listOf(3f, 2f, 1f), fullResult.chapterUpdates.map { it.chapter_number })
+        assertEquals(listOf(3f, 1f), filteredResult.chapterUpdates.map { it.chapter_number })
+    }
+
+    @Test
+    fun `filtered chapter list understates local continuous progress`() {
+        val fullResult = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 4f, sourceOrder = 0, read = true),
+                chapter(number = 3f, sourceOrder = 1, read = true),
+                chapter(number = 2f, sourceOrder = 2, read = true),
+                chapter(number = 1f, sourceOrder = 3, read = true),
+            ),
+            remoteLastRead = 0f,
+        )
+        val filteredResult = calculateTwoWayTrackerSync(
+            chapters = listOf(
+                chapter(number = 4f, sourceOrder = 0, read = true),
+                chapter(number = 1f, sourceOrder = 3, read = true),
+            ),
+            remoteLastRead = 0f,
+        )
+
+        assertEquals(4f, fullResult.localLastRead)
+        assertEquals(1f, filteredResult.localLastRead)
+    }
+
+    private fun chapter(number: Float, sourceOrder: Int, read: Boolean): Chapter {
+        return Chapter.create().apply {
+            id = (sourceOrder + 1).toLong()
+            manga_id = 1L
+            chapter_number = number
+            source_order = sourceOrder
+            this.read = read
+            bookmark = false
+            last_page_read = 0
+            pages_left = 0
+            date_fetch = 0L
+            name = "Chapter $number"
+            url = "/$number"
+        }
+    }
+}

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -589,11 +589,12 @@
     <string name="tracked">Tracked</string>
     <string name="not_tracked">Not tracked</string>
     <string name="services">Services</string>
-    <string name="tracking_info">One-way sync to update the chapter progress in tracking services. Set up tracking for individual entries from their tracking button.</string>
+    <string name="tracking_info">Two-way sync for chapter progress in tracking services. Set up tracking for individual entries from their tracking button.</string>
     <string name="enhanced_services">Enhanced services</string>
     <string name="enhanced_tracking_info">Services that provide enhanced features for specific sources. Entries are automatically tracked when added to your library.</string>
     <string name="update_tracking_after_reading">Update tracking after reading</string>
     <string name="update_tracking_marked_read">Update tracking when marked as read</string>
+    <string name="pref_auto_sync_progress_from_trackers">Auto sync progress from trackers</string>
     <string name="reading">Reading</string>
     <string name="currently_reading">Currently Reading</string>
     <string name="dropped">Dropped</string>
@@ -846,6 +847,7 @@
     <string name="updates_covers_genres_desc">Updates covers, genres, description and entries status information</string>
     <string name="refresh_tracking_metadata">Refresh tracking metadata</string>
     <string name="updates_tracking_details">Updates status, score and last chapter read from the tracking services</string>
+    <string name="sync_progress_from_trackers_up_to_chapter">Synced progress from trackers up to chapter %1$d</string>
     <string name="clean_up_downloaded_chapters">Clean up downloaded chapters</string>
     <string name="delete_unused_chapters">Delete non-existent, partially downloaded,
         and read chapter folders</string>

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -847,7 +847,7 @@
     <string name="updates_covers_genres_desc">Updates covers, genres, description and entries status information</string>
     <string name="refresh_tracking_metadata">Refresh tracking metadata</string>
     <string name="updates_tracking_details">Updates status, score and last chapter read from the tracking services</string>
-    <string name="sync_progress_from_trackers_up_to_chapter">Synced progress from trackers up to chapter %1$d</string>
+    <string name="sync_progress_from_trackers_up_to_chapter">Synced progress from trackers up to chapter %1$s</string>
     <string name="clean_up_downloaded_chapters">Clean up downloaded chapters</string>
     <string name="delete_unused_chapters">Delete non-existent, partially downloaded,
         and read chapter folders</string>


### PR DESCRIPTION
## Summary
- Adds two-way chapter progress syncing between local chapters and tracking services, including support for fractional chapter numbers and duplicate chapter variants.
- Introduces an `Auto sync progress from trackers` setting and uses tracker refresh results to update local read state when enabled.
- Updates manga details UI to rebind visible headers after chapter list refreshes and shows a toast when tracker progress is synced.
- Expands sync logic to preserve covered chapter variants and adds unit coverage for monotonic, regression, duplicate-variant, and mixed fractional chapter cases.