### PR TITLE
fix(chapters): correctly update download status on allChapters with scanlator filter

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -275,14 +275,21 @@ class MangaDetailsPresenter(
     }
 
     private suspend fun getChapters(queue: List<Download> = downloadManager.queueState.value) {
-        val chapters = getChapter.awaitAll(mangaId, isScanlatorFiltered()).map { it.toModel() }
-        allChapters = if (!isScanlatorFiltered()) chapters else getChapter.awaitAll(mangaId, false).map { it.toModel() }
+        val isScanlatorFiltered = isScanlatorFiltered()
+        val filteredChapters = getChapter.awaitAll(mangaId, isScanlatorFiltered).map { it.toModel() }
 
-        // Find downloaded chapters
-        setDownloadedChapters(chapters, queue)
+        allChapters = if (isScanlatorFiltered) {
+            getChapter.awaitAll(mangaId, false).map { it.toModel() }
+        }else{
+            filteredChapters
+        }   
+         // Find downloaded chapters
+        setDownloadedChapters(allChapters, queue)
+        if (isScanlatorFiltered) {
+            setDownloadedChapters(filteredChapters, queue)
+        }
         allChapterScanlators = allChapters.mapNotNull { it.chapter.scanlator }.toSet()
-
-        this.chapters = applyChapterFilters(chapters)
+        this.chapters = applyChapterFilters(filteredChapters)
     }
 
     private suspend fun getHistory() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/chapter/ReaderChapterSheet.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/chapter/ReaderChapterSheet.kt
@@ -208,7 +208,7 @@ class ReaderChapterSheet @JvmOverloads constructor(context: Context, attrs: Attr
                 false
             } else {
                 viewModel.toggleRead(item.chapter)
-                refreshList()
+                refreshList(scrollToCurrent = false)
                 true
             }
         }
@@ -229,8 +229,10 @@ class ReaderChapterSheet @JvmOverloads constructor(context: Context, attrs: Attr
                     item: ReaderChapterItem,
                 ) {
                     if (!activity.isLoading && sheetBehavior.isExpanded()) {
-                        viewModel.toggleBookmark(item.chapter)
-                        refreshList()
+                            activity.lifecycleScope.launch {
+                            viewModel.toggleBookmark(item.chapter)
+                            fastAdapter.notifyItemChanged(position)
+                        }
                     }
                 }
             },
@@ -269,18 +271,33 @@ class ReaderChapterSheet @JvmOverloads constructor(context: Context, attrs: Attr
         itemView?.progress?.isVisible = false
     }
 
-    fun refreshList() {
+    fun refreshList(scrollToCurrent: Boolean = true) {
         launchUI {
             val chapters = viewModel.getChapters()
 
             selectedChapterId = chapters.find { it.isCurrent }?.chapter?.id ?: -1L
+            val layoutManager = binding.chapterRecycler.layoutManager as LinearLayoutManager
+            
+            var firstVisible = -1
+            var offset = 0
+            if (!scrollToCurrent) {
+                firstVisible = layoutManager.findFirstVisibleItemPosition()
+                offset = layoutManager.findViewByPosition(firstVisible)?.top ?: 0
+            }
+
             itemAdapter.clear()
             itemAdapter.add(chapters)
 
-            (binding.chapterRecycler.layoutManager as LinearLayoutManager).scrollToPositionWithOffset(
-                adapter?.getPosition(viewModel.getCurrentChapter()?.chapter?.id ?: 0L) ?: 0,
-                binding.chapterRecycler.height / 2 - 30.dpToPx,
-            )
+            if (scrollToCurrent) {
+                layoutManager.scrollToPositionWithOffset(
+                    adapter?.getPosition(viewModel.getCurrentChapter()?.chapter?.id ?: 0L) ?: 0,
+                    binding.chapterRecycler.height / 2 - 30.dpToPx,
+                )
+            } else if (firstVisible != -1) {
+                binding.chapterRecycler.post {
+                    layoutManager.scrollToPositionWithOffset(firstVisible, offset)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This PR fixes the "Remove downloads" option in the overflow menu not working properly when the scanlator filter is active.

Fixes #587

- [x] Tested manually 

<!--
^ Please summarise the changes you have made here ^
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
