### PR TITLE
Fix migration UI crash, various performance & QoL changes

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
@@ -20,6 +20,7 @@ data class LibraryManga(
     companion object {
         // Used by findAll (one-shot fetch) — includes description
         fun mapper(
+            // manga
             id: Long,
             source: Long,
             url: String,
@@ -40,6 +41,7 @@ data class LibraryManga(
             filteredScanlators: String?,
             updateStrategy: Long,
             coverLastModified: Long,
+            // libraryManga
             total: Long,
             readCount: Double,
             bookmarkCount: Double,
@@ -83,6 +85,7 @@ data class LibraryManga(
         // Used by findAllAsFlow (reactive subscription) — excludes description to
         // avoid CursorWindow overflow on large libraries with frequent re-emissions.
         fun flowMapper(
+            // manga
             id: Long,
             source: Long,
             url: String,
@@ -102,6 +105,7 @@ data class LibraryManga(
             filteredScanlators: String?,
             updateStrategy: Long,
             coverLastModified: Long,
+            // libraryManga
             total: Long,
             readCount: Double,
             bookmarkCount: Double,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
@@ -18,8 +18,8 @@ data class LibraryManga(
         get() = read > 0
 
     companion object {
+        // Used by findAll (one-shot fetch) — includes description
         fun mapper(
-            // manga
             id: Long,
             source: Long,
             url: String,
@@ -40,7 +40,6 @@ data class LibraryManga(
             filteredScanlators: String?,
             updateStrategy: Long,
             coverLastModified: Long,
-            // libraryManga
             total: Long,
             readCount: Double,
             bookmarkCount: Double,
@@ -56,6 +55,68 @@ data class LibraryManga(
                 artist = artist,
                 author = author,
                 description = description,
+                genre = genre,
+                title = title,
+                status = status,
+                thumbnailUrl = thumbnailUrl,
+                favorite = favorite,
+                lastUpdate = lastUpdate,
+                initialized = initialized,
+                viewerFlags = viewerFlags,
+                hideTitle = hideTitle,
+                chapterFlags = chapterFlags,
+                dateAdded = dateAdded,
+                filteredScanlators = filteredScanlators,
+                updateStrategy = updateStrategy,
+                coverLastModified = coverLastModified,
+            ),
+            read = readCount.roundToInt(),
+            unread = maxOf((total - readCount).roundToInt(), 0),
+            totalChapters = total.toInt(),
+            bookmarkCount = bookmarkCount.roundToInt(),
+            category = categoryId.toInt(),
+            latestUpdate = latestUpdate,
+            lastRead = lastRead,
+            lastFetch = lastFetch,
+        )
+
+        // Used by findAllAsFlow (reactive subscription) — excludes description to
+        // avoid CursorWindow overflow on large libraries with frequent re-emissions.
+        fun flowMapper(
+            id: Long,
+            source: Long,
+            url: String,
+            artist: String?,
+            author: String?,
+            genre: String?,
+            title: String,
+            status: Long,
+            thumbnailUrl: String?,
+            favorite: Boolean,
+            lastUpdate: Long?,
+            initialized: Boolean,
+            viewerFlags: Long,
+            hideTitle: Boolean,
+            chapterFlags: Long,
+            dateAdded: Long?,
+            filteredScanlators: String?,
+            updateStrategy: Long,
+            coverLastModified: Long,
+            total: Long,
+            readCount: Double,
+            bookmarkCount: Double,
+            categoryId: Long,
+            latestUpdate: Long,
+            lastRead: Long,
+            lastFetch: Long,
+        ): LibraryManga = LibraryManga(
+            manga = Manga.mapper(
+                id = id,
+                source = source,
+                url = url,
+                artist = artist,
+                author = author,
+                description = null,
                 genre = genre,
                 title = title,
                 status = status,

--- a/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/library/LibraryUpdateJob.kt
@@ -583,9 +583,18 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
     }
 
     private fun addCategory(categoryId: Int) {
-        val mangas = filterMangaToUpdate(runBlocking { getMangaToUpdate(categoryId) }).sortedBy { it.manga.title }
-        categoryIds.add(categoryId)
-        addManga(mangas)
+        // getMangaToUpdate() calls getLibraryManga.await(), which fetches the whole library
+        // from the database. This used to run via runBlocking{} directly on the calling
+        // thread - since addCategory() is invoked from startNow(), which itself runs on the
+        // UI thread from a button tap, that blocked the UI for as long as the query took.
+        // That DB query competes with the already-running job's own heavy DB/network
+        // activity, which is what caused the multi-second freeze when adding a second
+        // category to an already in-progress update.
+        extraScope.launch {
+            val mangas = filterMangaToUpdate(getMangaToUpdate(categoryId)).sortedBy { it.manga.title }
+            categoryIds.add(categoryId)
+            addManga(mangas)
+        }
     }
 
     private fun addManga(mangaToAdd: List<LibraryManga>) {
@@ -707,6 +716,15 @@ class LibraryUpdateJob(private val context: Context, workerParams: WorkerParamet
         }
 
         fun isRunning(context: Context): Boolean {
+            // instance is set the moment doWork() actually starts and cleared to null the moment
+            // it finishes (see doWork()'s finally block), so it has the exact same lifetime as
+            // "is a job currently running." Checking it first avoids a blocking
+            // WorkManager.getWorkInfosByTag(TAG).get() call on the calling thread whenever a job
+            // is already running in this process - a cheap in-memory check instead of a WorkManager
+            // round-trip. Falls through to the WorkManager query only when nothing is running
+            // locally (e.g. checking from a fresh process), where it's a fast query anyway since
+            // there's nothing active to look up.
+            if (instance?.get() != null) return true
             val list = WorkManager.getInstance(context).getWorkInfosByTag(TAG).get()
             return list.any { it.state == WorkInfo.State.RUNNING }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryCategoryAdapter.kt
@@ -311,5 +311,6 @@ class LibraryCategoryAdapter(val controller: LibraryController?) :
         fun toggleCategoryVisibility(position: Int)
         fun manageCategory(position: Int)
         fun globalSearch(query: String)
+        fun isCategoryUpdating(categoryId: Int?): Boolean
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -1128,7 +1128,15 @@ open class LibraryController(
             return
         }
         view ?: return
-        destroyActionModeIfNeeded()
+        // Only destroy action mode if no manga are selected, or if none of the
+        // selected manga exist in the updated library list (e.g. deleted/filtered out).
+        // Previously this fired unconditionally, wiping selection on every chapter
+        // download completion when the library flow re-emitted.
+        if (selectedMangas.isEmpty() || selectedMangas.none { selected ->
+                mangaMap.filterIsInstance<LibraryMangaItem>().any { it.manga.manga.id == selected.id }
+            }) {
+            destroyActionModeIfNeeded()
+        }
         if (mangaMap.isNotEmpty()) {
             if (!binding.progress.isVisible) {
                 (activity as? MainActivity)?.showNotificationPermissionPrompt()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryController.kt
@@ -200,6 +200,18 @@ open class LibraryController(
      */
     private val selectedMangas = mutableSetOf<Manga>()
 
+    // Categories the user has explicitly triggered an update for, that we're still waiting on
+    // isRunningFlow to confirm as finished. LibraryUpdateJob.categoryInQueue() can't be trusted
+    // right after starting a job - categoryIds gets populated a few lines into doWork(), so any
+    // header rebind that happens to land in that window (or is caused by something unrelated,
+    // like a badge/preference update) reads categoryInQueue() == false and stomps the spinner
+    // back off well before the job is actually done.
+    private val pendingManualCategoryUpdates = mutableSetOf<Int>()
+
+    override fun isCategoryUpdating(categoryId: Int?): Boolean {
+        return LibraryUpdateJob.categoryInQueue(categoryId) || (categoryId != null && categoryId in pendingManualCategoryUpdates)
+    }
+
     private var mAdapter: LibraryCategoryAdapter? = null
     private val adapter: LibraryCategoryAdapter
         get() = mAdapter!!
@@ -616,11 +628,12 @@ open class LibraryController(
         setPreferenceFlows()
         LibraryUpdateJob.updateFlow.onEach(::onUpdateManga).launchIn(viewScope)
         viewScope.launchUI {
-            LibraryUpdateJob.isRunningFlow(view.context).collect {
+            LibraryUpdateJob.isRunningFlow(view.context).collect { isRunning ->
+                if (!isRunning) pendingManualCategoryUpdates.clear()
                 adapter.getHeaderPositions().forEach {
                     val holder = (binding.libraryGridRecycler.recycler.findViewHolderForAdapterPosition(it) as? LibraryHeaderHolder) ?: return@forEach
                     val category = holder.category ?: return@forEach
-                    holder.notifyStatus(LibraryUpdateJob.categoryInQueue(category.id), category)
+                    holder.notifyStatus(isCategoryUpdating(category.id), category)
                 }
             }
         }
@@ -971,6 +984,16 @@ open class LibraryController(
     private fun updateLibrary(category: Category? = null) {
         val view = view ?: return
         LibraryUpdateJob.startNow(view.context, category)
+        if (category != null) {
+            category.id?.let { pendingManualCategoryUpdates.add(it) }
+        } else {
+            presenter.categories.mapNotNull { it.id }.forEach { pendingManualCategoryUpdates.add(it) }
+        }
+        adapter.getHeaderPositions().forEach {
+            val holder = (binding.libraryGridRecycler.recycler.findViewHolderForAdapterPosition(it) as? LibraryHeaderHolder) ?: return@forEach
+            val cat = holder.category ?: return@forEach
+            holder.notifyStatus(isCategoryUpdating(cat.id), cat)
+        }
         snack = view.snack(MR.strings.updating_library) {
             anchorView = anchorView()
             this.view.elevation = 15f.dpToPx
@@ -1788,6 +1811,7 @@ open class LibraryController(
             }
         }
         if (!inQueue) {
+            category.id?.let { pendingManualCategoryUpdates.add(it) }
             LibraryUpdateJob.startNow(
                 view!!.context,
                 category,

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryGridHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryGridHolder.kt
@@ -99,10 +99,16 @@ class LibraryGridHolder(
         setUnreadBadge(binding.unreadDownloadBadge.badgeView, item)
         setReadingButton(item)
         setSelected(adapter.isSelected(flexibleAdapterPosition))
-
-        // Update the cover.
-        binding.coverThumbnail.dispose()
-        setCover(item.manga.manga)
+        // Only reload cover if it has actually changed, to avoid grey flash on
+        // library flow re-emissions (e.g. when tabbing back into the app).
+        val mangaId = item.manga.manga.id
+        val coverModified = item.manga.manga.cover_last_modified
+        if (binding.coverThumbnail.tag != mangaId || coverModified != (binding.coverThumbnail.getTag(R.id.manga_cover_modified) as? Long)) {
+            binding.coverThumbnail.tag = mangaId
+            binding.coverThumbnail.setTag(R.id.manga_cover_modified, coverModified)
+            binding.coverThumbnail.dispose()
+            setCover(item.manga.manga)
+        }
     }
 
     override fun toggleActivation() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryHeaderHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/library/LibraryHeaderHolder.kt
@@ -222,7 +222,7 @@ class LibraryHeaderHolder(val view: View, val adapter: LibraryCategoryAdapter) :
                 R.drawable.ic_expand_less_24dp
             },
         )
-        notifyStatus(LibraryUpdateJob.categoryInQueue(category.id), category)
+        notifyStatus(adapter.libraryListener?.isCategoryUpdating(category.id) == true, category)
     }
 
     @SuppressLint("DiscouragedApi")

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsController.kt
@@ -917,7 +917,18 @@ class MangaDetailsController :
         colorToolbar(binding.recycler.canScrollVertically(-1))
         updateMenuVisibility(activityBinding?.toolbar?.menu)
     }
-
+    // Lightweight update for single chapter read/bookmark toggles.
+    // Skips full adapter dataset replacement which caused ~1s freeze when at top of chapter selection screen.
+    // Also part of a fix for manual chapter marking read/unread/bookmarks skipping entries usuallyy 6/20 times.
+    // Now can manually mark any amount of chapters 1 by 1 without ANY misses or latency issues.
+    fun updateChaptersQuick(chapterId: Long) {
+        view ?: return
+        val position = adapter?.indexOf(chapterId) ?: return
+        if (position >= 0) adapter?.notifyItemChanged(position)
+        getHeader()?.updateReadingButton()
+        updateFab()
+        updateMenuVisibility(activityBinding?.toolbar?.menu)
+    }
     private fun addMangaHeader() {
         val tabletHeader = presenter.tabletChapterHeaderItem
         if (tabletHeader != null && tabletAdapter?.scrollableHeaders?.isEmpty() == true) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -104,7 +104,6 @@ import yokai.domain.track.interactor.GetTrack
 import yokai.domain.track.interactor.InsertTrack
 import yokai.i18n.MR
 import yokai.util.lang.getString
-import kotlinx.coroutines.flow.debounce
 
 class MangaDetailsPresenter(
     val mangaId: Long,
@@ -205,7 +204,6 @@ class MangaDetailsPresenter(
         }
         presenterScope.launchIO {
             downloadManager.queueState
-                .debounce(500L)
                 .collectLatest(::onQueueUpdate)
         }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -104,6 +104,7 @@ import yokai.domain.track.interactor.GetTrack
 import yokai.domain.track.interactor.InsertTrack
 import yokai.i18n.MR
 import yokai.util.lang.getString
+import kotlinx.coroutines.flow.debounce
 
 class MangaDetailsPresenter(
     val mangaId: Long,
@@ -187,7 +188,7 @@ class MangaDetailsPresenter(
         val controller = view ?: return
 
         isLockedFromSearch = controller.shouldLockIfNeeded && SecureActivityDelegate.shouldBeLocked()
-        if (!::manga.isInitialized) runBlocking { refreshMangaFromDb() }
+        if (!::manga.isInitialized || manga.description == null) runBlocking { refreshMangaFromDb() }
         syncData()
 
         presenterScope.launchUI {
@@ -203,7 +204,9 @@ class MangaDetailsPresenter(
                 .collect(::onQueueUpdate)
         }
         presenterScope.launchIO {
-            downloadManager.queueState.collectLatest(::onQueueUpdate)
+            downloadManager.queueState
+                .debounce(500L)
+                .collectLatest(::onQueueUpdate)
         }
 
         runBlocking {
@@ -540,8 +543,13 @@ class MangaDetailsPresenter(
                 it.toProgressUpdate()
             }
             updateChapter.awaitAll(updates)
-            getChapters()
-            withUIContext { view?.updateChapters() }
+            if (selectedChapters.size == 1) {
+                getChapters()
+                withUIContext { view?.updateChaptersQuick(selectedChapters.first().id ?: return@withUIContext) }
+            } else {
+                getChapters()
+                withUIContext { view?.updateChapters() }
+            }
         }
     }
 
@@ -570,8 +578,13 @@ class MangaDetailsPresenter(
             if (read && deleteNow && preferences.removeAfterMarkedAsRead().get()) {
                 deleteChapters(selectedChapters, false)
             }
-            getChapters()
-            withUIContext { view?.updateChapters() }
+            if (selectedChapters.size == 1) {
+                getChapters()
+                withUIContext { view?.updateChaptersQuick(selectedChapters.first().id ?: return@withUIContext) }
+            } else {
+                getChapters()
+                withUIContext { view?.updateChapters() }
+            }
             if (read && deleteNow) {
                 val latestReadChapter = selectedChapters.maxByOrNull { it.chapter_number.toInt() }?.chapter
                 updateTrackChapterMarkedAsRead(preferences, latestReadChapter, manga.id) {
@@ -1119,6 +1132,10 @@ class MangaDetailsPresenter(
     }
 
     private suspend fun onQueueUpdate(queue: List<Download>) = withIOContext {
+        // Only rebuild if this manga has chapters in the queue.
+        // Without this, every download progress tick for any manga triggers
+        // a full chapter list rebuild and RecyclerView rebind, causing excessive scroll stutter.
+        if (queue.none { it.manga.id == mangaId }) return@withIOContext
         getChapters(queue)
         withUIContext {
             view?.updateChapters()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaDetailsPresenter.kt
@@ -1129,11 +1129,16 @@ class MangaDetailsPresenter(
         onPageProgressUpdate(download)
     }
 
+    private var hadQueuedChapters = false
+
     private suspend fun onQueueUpdate(queue: List<Download>) = withIOContext {
-        // Only rebuild if this manga has chapters in the queue.
-        // Without this, every download progress tick for any manga triggers
-        // a full chapter list rebuild and RecyclerView rebind, causing excessive scroll stutter.
-        if (queue.none { it.manga.id == mangaId }) return@withIOContext
+        // Skip rebuilds for manga unrelated to this screen (avoids stutter),
+        // but still rebuild on the transition to empty - otherwise the final
+        // "download complete" update gets skipped since the chapter is already
+        // removed from the queue by the time this fires.
+        val hasQueuedNow = queue.any { it.manga.id == mangaId }
+        if (!hasQueuedNow && !hadQueuedChapters) return@withIOContext
+        hadQueuedChapters = hasQueuedNow
         getChapters(queue)
         withUIContext {
             view?.updateChapters()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaHeaderHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/manga/MangaHeaderHolder.kt
@@ -295,7 +295,39 @@ class MangaHeaderHolder(
             chapterBinding.filtersText.text = presenter.currentFilters()
         }
     }
-
+    // updatereadingbutton fixes issue where fixing skipped chapter marking & latency caused button text to not update until reloaded
+    // though it still functioned properly without correct chapter number text, directing to correct unread chapter number.
+    // Updating this button still introduces slight latency when manuallying marking chapters with header visible but is near nonexistent now.
+    fun updateReadingButton() {
+        val presenter = adapter.delegate.mangaPresenter()
+        val nextChapter = presenter.getNextUnreadChapter()
+        with(binding?.startReadingButton ?: return) {
+            isEnabled = (nextChapter != null)
+            text = if (nextChapter != null) {
+                val number = adapter.decimalFormat.format(nextChapter.chapter_number.toDouble())
+                if (nextChapter.chapter_number > 0) {
+                    context.getString(
+                        if (nextChapter.last_page_read > 0) {
+                            MR.strings.continue_reading_chapter_
+                        } else {
+                            MR.strings.start_reading_chapter_
+                        },
+                        number,
+                    )
+                } else {
+                    context.getString(
+                        if (nextChapter.last_page_read > 0) {
+                            MR.strings.continue_reading
+                        } else {
+                            MR.strings.start_reading
+                        },
+                    )
+                }
+            } else {
+                context.getString(MR.strings.all_chapters_read)
+            }
+        }
+    }
     @SuppressLint("SetTextI18n", "StringFormatInvalid")
     fun bind(item: MangaHeaderItem) {
         val presenter = adapter.delegate.mangaPresenter()

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigratingManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigratingManga.kt
@@ -52,6 +52,7 @@ class MigratingManga(
     }
 
     fun toModal(): MigrationProcessItem {
+        // Create the model object.
         return MigrationProcessItem(this)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigratingManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigratingManga.kt
@@ -5,8 +5,10 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.util.view.DeferredField
 import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import uy.kohesive.injekt.injectLazy
 import yokai.domain.manga.interactor.GetManga
@@ -22,12 +24,19 @@ class MigratingManga(
     // <MAX, PROGRESS>
     val progress = MutableStateFlow(1 to 0)
 
-    val migrationJob = parentContext + SupervisorJob() + Dispatchers.Default
+    // A proper CoroutineScope (not just a CoroutineContext) so it can be
+    // cleanly cancelled and its children are tracked. SupervisorJob means
+    // one failing source search doesn't cancel sibling searches.
+    val migrationScope = CoroutineScope(parentContext + SupervisorJob() + Dispatchers.Default)
+
+    // Keep a context reference for call sites that need CoroutineContext directly.
+    val migrationJob: CoroutineContext get() = migrationScope.coroutineContext
 
     var migrationStatus: Int = MigrationStatus.RUNNUNG
 
     @Volatile
     private var manga: Manga? = null
+
     suspend fun manga(): Manga? {
         if (manga == null) manga = getManga.awaitById(mangaId)
         return manga
@@ -37,8 +46,12 @@ class MigratingManga(
         return sourceManager.getOrStub(manga()?.source ?: -1)
     }
 
+    /** Cancel all in-flight coroutines for this manga entry. */
+    fun cancel() {
+        migrationScope.cancel()
+    }
+
     fun toModal(): MigrationProcessItem {
-        // Create the model object.
         return MigrationProcessItem(this)
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationListController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationListController.kt
@@ -406,16 +406,32 @@ class MigrationListController(bundle: Bundle? = null) :
 
     fun migrateMangas() {
         launchUI {
-            adapter?.performMigrations(false)
+            val dialog = showMigrationProgressDialog()
+            adapter?.performMigrations(false) { current, total ->
+                dialog.setMessage("$current / $total")
+            }
+            dialog.dismiss()
             navigateOut()
         }
     }
 
     fun copyMangas() {
         launchUI {
-            adapter?.performMigrations(true)
+            val dialog = showMigrationProgressDialog()
+            adapter?.performMigrations(true) { current, total ->
+                dialog.setMessage("$current / $total")
+            }
+            dialog.dismiss()
             navigateOut()
         }
+    }
+
+    private fun showMigrationProgressDialog(): androidx.appcompat.app.AlertDialog {
+        return activity!!.materialAlertDialog()
+            .setTitle(MR.strings.migrating_progress)
+            .setMessage("0 / 0")
+            .setCancelable(false)
+            .show()
     }
 
     private fun navigateOut() {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessAdapter.kt
@@ -54,7 +54,12 @@ class MigrationProcessAdapter(
     var showOutline = uiPreferences.outlineOnCovers().get()
     val menuItemListener: MigrationProcessInterface = controller
 
-    private val enhancedServices by lazy { Injekt.get<TrackManager>().services.filterIsInstance<EnhancedTrackService>() }
+    private val enhancedServices by lazy {
+        Injekt.get<TrackManager>().services.filterIsInstance<EnhancedTrackService>()
+    }
+
+    // NEW: batch safety (snapshot of items used in Migrate All)
+    private var migrationBatch: List<MigrationProcessItem> = emptyList()
 
     override fun updateDataSet(items: List<MigrationProcessItem>?) {
         this.items = items ?: emptyList()
@@ -82,24 +87,33 @@ class MigrationProcessAdapter(
 
     fun allMangasDone() = (
         items.all {
-            it.manga.migrationStatus != MigrationStatus
-                .RUNNUNG
+            it.manga.migrationStatus != MigrationStatus.RUNNUNG
         } && items.any { it.manga.migrationStatus == MigrationStatus.MANGA_FOUND }
         )
 
     fun mangasSkipped() =
-        (items.count { it.manga.migrationStatus == MigrationStatus.MANGA_NOT_FOUND })
+        items.count { it.manga.migrationStatus == MigrationStatus.MANGA_NOT_FOUND }
 
-    suspend fun performMigrations(copy: Boolean) {
+    // =========================
+    // FIXED MIGRATE ALL
+    // =========================
+    suspend fun performMigrations(copy: Boolean, onProgress: (current: Int, total: Int) -> Unit = { _, _ -> }) {
+        migrationBatch = currentItems.toList()
+        val total = migrationBatch.size
+
         withContext(Dispatchers.IO) {
-            currentItems.forEach { migratingManga ->
+            migrationBatch.forEachIndexed { index, migratingManga ->
                 val manga = migratingManga.manga
+
                 if (manga.searchResult.initialized) {
                     val toMangaObj =
-                        getManga.awaitById(manga.searchResult.get() ?: return@forEach) ?: return@forEach
-                    val prevManga = manga.manga() ?: return@forEach
-                    val source = sourceManager.get(toMangaObj.source) ?: return@forEach
+                        getManga.awaitById(manga.searchResult.get() ?: return@forEachIndexed)
+                            ?: return@forEachIndexed
+
+                    val prevManga = manga.manga() ?: return@forEachIndexed
+                    val source = sourceManager.get(toMangaObj.source) ?: return@forEachIndexed
                     val prevSource = sourceManager.get(prevManga.source)
+
                     migrateMangaInternal(
                         prevSource,
                         source,
@@ -108,17 +122,27 @@ class MigrationProcessAdapter(
                         !copy,
                     )
                 }
+
+                withContext(Dispatchers.Main) {
+                    onProgress(index + 1, total)
+                }
             }
         }
+
+        migrationBatch = emptyList()
     }
 
     fun migrateManga(position: Int, copy: Boolean) {
         launchUI {
             val manga = getItem(position)?.manga ?: return@launchUI
-            val toMangaObj = getManga.awaitById(manga.searchResult.get() ?: return@launchUI) ?: return@launchUI
+            val toMangaObj =
+                getManga.awaitById(manga.searchResult.get() ?: return@launchUI)
+                    ?: return@launchUI
+
             val prevManga = manga.manga() ?: return@launchUI
             val source = sourceManager.get(toMangaObj.source) ?: return@launchUI
             val prevSource = sourceManager.get(prevManga.source)
+
             migrateMangaInternal(
                 prevSource,
                 source,
@@ -126,6 +150,7 @@ class MigrationProcessAdapter(
                 toMangaObj,
                 !copy,
             )
+
             removeManga(position)
         }
     }
@@ -148,6 +173,7 @@ class MigrationProcessAdapter(
     ) {
         if (controller.config == null) return
         val flags = preferences.migrateFlags().get()
+
         migrateMangaInternal(
             flags,
             enhancedServices,
@@ -174,7 +200,6 @@ class MigrationProcessAdapter(
             manga: Manga,
             replace: Boolean,
         ) {
-            // Update chapters read
             if (MigrationFlags.hasChapters(flags)) {
                 val getChapter: GetChapter = Injekt.get()
                 val updateChapter: UpdateChapter = Injekt.get()
@@ -182,31 +207,39 @@ class MigrationProcessAdapter(
                 val upsertHistory: UpsertHistory = Injekt.get()
 
                 val prevMangaChapters = getChapter.awaitAll(prevManga, false)
-                val maxChapterRead = prevMangaChapters.filter { it.read }.maxOfOrNull { it.chapter_number } ?: 0f
+                val maxChapterRead =
+                    prevMangaChapters.filter { it.read }.maxOfOrNull { it.chapter_number } ?: 0f
+
                 val dbChapters = getChapter.awaitAll(manga, false)
                 val prevHistoryList = getHistory.awaitAllByMangaId(prevManga.id!!)
+
                 val historyList = mutableListOf<History>()
                 val chapterUpdates = mutableListOf<ChapterUpdate>()
+
                 for (chapter in dbChapters) {
                     if (chapter.isRecognizedNumber) {
                         var update: ChapterUpdate? = null
+
                         val prevChapter =
-                            prevMangaChapters.find { it.isRecognizedNumber && it.chapter_number == chapter.chapter_number }
+                            prevMangaChapters.find {
+                                it.isRecognizedNumber &&
+                                    it.chapter_number == chapter.chapter_number
+                            }
+
                         if (prevChapter != null) {
-                            // copy data from prevChapter -> chapter
                             update = ChapterUpdate(
                                 id = chapter.id!!,
                                 bookmark = prevChapter.bookmark,
                                 read = prevChapter.read,
                                 dateFetch = prevChapter.date_fetch,
                             )
+
                             prevHistoryList.find { it.chapter_id == prevChapter.id }
                                 ?.let { prevHistory ->
-                                    val history = History.create(chapter)
-                                        .apply {
-                                            last_read = prevHistory.last_read
-                                            time_read = prevHistory.time_read
-                                        }
+                                    val history = History.create(chapter).apply {
+                                        last_read = prevHistory.last_read
+                                        time_read = prevHistory.time_read
+                                    }
                                     historyList.add(history)
                                 }
                         } else if (chapter.chapter_number <= maxChapterRead) {
@@ -215,18 +248,23 @@ class MigrationProcessAdapter(
                                 read = true
                             )
                         }
+
                         update?.let { chapterUpdates.add(it) }
                     }
                 }
+
                 updateChapter.awaitAll(chapterUpdates)
                 upsertHistory.awaitBulk(historyList)
             }
-            // Update categories
+
             if (MigrationFlags.hasCategories(flags)) {
                 val categories = Injekt.get<GetCategories>().awaitByMangaId(prevManga.id)
-                Injekt.get<SetMangaCategories>().await(manga.id, categories.mapNotNull { it.id?.toLong() })
+                Injekt.get<SetMangaCategories>().await(
+                    manga.id,
+                    categories.mapNotNull { it.id?.toLong() }
+                )
             }
-            // Update track
+
             if (MigrationFlags.hasTracks(flags)) {
                 val tracksToUpdate =
                     Injekt.get<GetTrack>().awaitAllByMangaId(prevManga.id).mapNotNull { track ->
@@ -235,16 +273,19 @@ class MigrationProcessAdapter(
 
                         val service = enhancedServices
                             .firstOrNull { it.isTrackFrom(track, prevManga, prevSource) }
+
                         if (service != null) {
                             service.migrateTrack(track, manga, source)
                         } else {
                             track
                         }
                     }
+
                 Injekt.get<InsertTrack>().awaitBulk(tracksToUpdate)
             }
+
             val updateManga: UpdateManga = Injekt.get()
-            // Update favorite status
+
             if (replace) {
                 prevManga.favorite = false
                 updateManga.await(
@@ -256,20 +297,25 @@ class MigrationProcessAdapter(
             }
 
             manga.favorite = true
-            if (replace) {
-                manga.date_added = prevManga.date_added
-            } else {
-                manga.date_added = Date().time
-            }
 
-            // Update custom cover & info
+            manga.date_added =
+                if (replace) prevManga.date_added else Date().time
+
             if (MigrationFlags.hasCustomMangaInfo(flags)) {
                 if (coverCache.getCustomCoverFile(prevManga).exists()) {
-                    coverCache.setCustomCoverToCache(manga, coverCache.getCustomCoverFile(prevManga).inputStream())
+                    coverCache.setCustomCoverToCache(
+                        manga,
+                        coverCache.getCustomCoverFile(prevManga).inputStream()
+                    )
                     manga.updateCoverLastModified()
                 }
+
                 customMangaManager.getManga(prevManga)?.let { customManga ->
-                    customMangaManager.updateMangaInfo(prevManga.id, manga.id, customManga.getMangaInfo())
+                    customMangaManager.updateMangaInfo(
+                        prevManga.id,
+                        manga.id,
+                        customManga.getMangaInfo()
+                    )
                 }
             }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessAdapter.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.ui.migration.manga.process
 
 import android.view.MenuItem
+import androidx.recyclerview.widget.RecyclerView
 import eu.davidea.flexibleadapter.FlexibleAdapter
 import eu.kanade.tachiyomi.data.cache.CoverCache
 import eu.kanade.tachiyomi.data.database.models.History
@@ -58,6 +59,11 @@ class MigrationProcessAdapter(
     override fun updateDataSet(items: List<MigrationProcessItem>?) {
         this.items = items ?: emptyList()
         super.updateDataSet(items)
+    }
+
+    override fun onViewRecycled(holder: RecyclerView.ViewHolder) {
+        super.onViewRecycled(holder)
+        (holder as? MigrationProcessHolder)?.onRecycled()
     }
 
     interface MigrationProcessInterface {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessAdapter.kt
@@ -57,7 +57,6 @@ class MigrationProcessAdapter(
     private val enhancedServices by lazy {
         Injekt.get<TrackManager>().services.filterIsInstance<EnhancedTrackService>()
     }
-
     // NEW: batch safety (snapshot of items used in Migrate All)
     private var migrationBatch: List<MigrationProcessItem> = emptyList()
 
@@ -104,7 +103,6 @@ class MigrationProcessAdapter(
         withContext(Dispatchers.IO) {
             migrationBatch.forEachIndexed { index, migratingManga ->
                 val manga = migratingManga.manga
-
                 if (manga.searchResult.initialized) {
                     val toMangaObj =
                         getManga.awaitById(manga.searchResult.get() ?: return@forEachIndexed)
@@ -113,7 +111,6 @@ class MigrationProcessAdapter(
                     val prevManga = manga.manga() ?: return@forEachIndexed
                     val source = sourceManager.get(toMangaObj.source) ?: return@forEachIndexed
                     val prevSource = sourceManager.get(prevManga.source)
-
                     migrateMangaInternal(
                         prevSource,
                         source,
@@ -122,13 +119,11 @@ class MigrationProcessAdapter(
                         !copy,
                     )
                 }
-
                 withContext(Dispatchers.Main) {
                     onProgress(index + 1, total)
                 }
             }
         }
-
         migrationBatch = emptyList()
     }
 
@@ -142,7 +137,6 @@ class MigrationProcessAdapter(
             val prevManga = manga.manga() ?: return@launchUI
             val source = sourceManager.get(toMangaObj.source) ?: return@launchUI
             val prevSource = sourceManager.get(prevManga.source)
-
             migrateMangaInternal(
                 prevSource,
                 source,
@@ -150,7 +144,6 @@ class MigrationProcessAdapter(
                 toMangaObj,
                 !copy,
             )
-
             removeManga(position)
         }
     }
@@ -173,7 +166,6 @@ class MigrationProcessAdapter(
     ) {
         if (controller.config == null) return
         val flags = preferences.migrateFlags().get()
-
         migrateMangaInternal(
             flags,
             enhancedServices,
@@ -200,6 +192,7 @@ class MigrationProcessAdapter(
             manga: Manga,
             replace: Boolean,
         ) {
+            // Update chapters read
             if (MigrationFlags.hasChapters(flags)) {
                 val getChapter: GetChapter = Injekt.get()
                 val updateChapter: UpdateChapter = Injekt.get()
@@ -209,17 +202,13 @@ class MigrationProcessAdapter(
                 val prevMangaChapters = getChapter.awaitAll(prevManga, false)
                 val maxChapterRead =
                     prevMangaChapters.filter { it.read }.maxOfOrNull { it.chapter_number } ?: 0f
-
                 val dbChapters = getChapter.awaitAll(manga, false)
                 val prevHistoryList = getHistory.awaitAllByMangaId(prevManga.id!!)
-
                 val historyList = mutableListOf<History>()
                 val chapterUpdates = mutableListOf<ChapterUpdate>()
-
                 for (chapter in dbChapters) {
                     if (chapter.isRecognizedNumber) {
                         var update: ChapterUpdate? = null
-
                         val prevChapter =
                             prevMangaChapters.find {
                                 it.isRecognizedNumber &&
@@ -227,13 +216,13 @@ class MigrationProcessAdapter(
                             }
 
                         if (prevChapter != null) {
+                            // copy data from prevChapter -> chapter
                             update = ChapterUpdate(
                                 id = chapter.id!!,
                                 bookmark = prevChapter.bookmark,
                                 read = prevChapter.read,
                                 dateFetch = prevChapter.date_fetch,
                             )
-
                             prevHistoryList.find { it.chapter_id == prevChapter.id }
                                 ?.let { prevHistory ->
                                     val history = History.create(chapter).apply {
@@ -248,15 +237,13 @@ class MigrationProcessAdapter(
                                 read = true
                             )
                         }
-
                         update?.let { chapterUpdates.add(it) }
                     }
                 }
-
                 updateChapter.awaitAll(chapterUpdates)
                 upsertHistory.awaitBulk(historyList)
             }
-
+            // Update categories
             if (MigrationFlags.hasCategories(flags)) {
                 val categories = Injekt.get<GetCategories>().awaitByMangaId(prevManga.id)
                 Injekt.get<SetMangaCategories>().await(
@@ -264,7 +251,7 @@ class MigrationProcessAdapter(
                     categories.mapNotNull { it.id?.toLong() }
                 )
             }
-
+            // Update track
             if (MigrationFlags.hasTracks(flags)) {
                 val tracksToUpdate =
                     Injekt.get<GetTrack>().awaitAllByMangaId(prevManga.id).mapNotNull { track ->
@@ -273,19 +260,16 @@ class MigrationProcessAdapter(
 
                         val service = enhancedServices
                             .firstOrNull { it.isTrackFrom(track, prevManga, prevSource) }
-
                         if (service != null) {
                             service.migrateTrack(track, manga, source)
                         } else {
                             track
                         }
                     }
-
                 Injekt.get<InsertTrack>().awaitBulk(tracksToUpdate)
             }
-
             val updateManga: UpdateManga = Injekt.get()
-
+            // Update favorite status
             if (replace) {
                 prevManga.favorite = false
                 updateManga.await(
@@ -297,7 +281,7 @@ class MigrationProcessAdapter(
             }
 
             manga.favorite = true
-
+            // Update custom cover & info
             manga.date_added =
                 if (replace) prevManga.date_added else Date().time
 

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessHolder.kt
@@ -54,6 +54,9 @@ class MigrationProcessHolder(
     private var bindJob: Job? = null
 
     init {
+        // We need to post a Runnable to show the popup to make sure that the PopupMenu is
+        // correctly positioned. The reason being that the view may change position before the
+        // PopupMenu is shown.
         binding.migrationMenu.setOnClickListener { it.post { showPopupMenu(it) } }
         binding.skipManga.setOnClickListener { it.post { adapter.removeManga(flexibleAdapterPosition) } }
         arrayOf(binding.migrationMangaCardFrom, binding.migrationMangaCardTo).forEach {
@@ -198,22 +201,28 @@ class MigrationProcessHolder(
     private fun showPopupMenu(view: View) {
         val item = adapter.getItem(flexibleAdapterPosition) ?: return
 
+        // Create a PopupMenu, giving it the clicked view for an anchor
         val popup = PopupMenu(view.context, view)
+
+        // Inflate our menu resource into the PopupMenu's Menu
         popup.menuInflater.inflate(R.menu.migration_single, popup.menu)
 
         val mangas = item.manga
 
         popup.menu.findItem(R.id.action_search_manually).isVisible = true
+        // Hide download and show delete if the chapter is downloaded
         if (mangas.searchResult.content != null) {
             popup.menu.findItem(R.id.action_migrate_now).isVisible = true
             popup.menu.findItem(R.id.action_copy_now).isVisible = true
         }
 
+        // Set a listener so we are notified if a menu item is clicked
         popup.setOnMenuItemClickListener { menuItem ->
             adapter.menuItemListener.onMenuItemClick(flexibleAdapterPosition, menuItem)
             true
         }
 
+        // Finally show the PopupMenu
         popup.show()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessHolder.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/migration/manga/process/MigrationProcessHolder.kt
@@ -15,12 +15,17 @@ import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.ui.base.holder.BaseFlexibleViewHolder
 import eu.kanade.tachiyomi.ui.library.setFreeformCoverRatio
 import eu.kanade.tachiyomi.ui.manga.MangaDetailsController
-import eu.kanade.tachiyomi.util.system.launchUI
 import eu.kanade.tachiyomi.util.view.setCards
 import eu.kanade.tachiyomi.util.view.setVectorCompat
 import eu.kanade.tachiyomi.util.view.withFadeTransaction
 import java.text.DecimalFormat
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import uy.kohesive.injekt.injectLazy
 import yokai.domain.chapter.interactor.GetChapter
@@ -42,10 +47,13 @@ class MigrationProcessHolder(
     private var item: MigrationProcessItem? = null
     private val binding = MigrationProcessItemBinding.bind(view)
 
+    // Each ViewHolder owns its own scope so bind() coroutines can be
+    // cancelled when the holder rebinds to a different item or is recycled,
+    // instead of accumulating as parked coroutines on the dispatcher.
+    private val holderScope = MainScope()
+    private var bindJob: Job? = null
+
     init {
-        // We need to post a Runnable to show the popup to make sure that the PopupMenu is
-        // correctly positioned. The reason being that the view may change position before the
-        // PopupMenu is shown.
         binding.migrationMenu.setOnClickListener { it.post { showPopupMenu(it) } }
         binding.skipManga.setOnClickListener { it.post { adapter.removeManga(flexibleAdapterPosition) } }
         arrayOf(binding.migrationMangaCardFrom, binding.migrationMangaCardTo).forEach {
@@ -57,7 +65,13 @@ class MigrationProcessHolder(
 
     fun bind(item: MigrationProcessItem) {
         this.item = item
-        launchUI {
+
+        // Cancel any previous bind coroutine for this holder before starting a new one.
+        // Without this, every notifyItemChanged() call (which sourceFinished() triggers)
+        // would park a new coroutine on searchResult.get()'s mutex, exhausting the
+        // dispatcher thread pool and causing the progressive UI slowdown.
+        bindJob?.cancel()
+        bindJob = holderScope.launch {
             binding.migrationMangaCardFrom.setFreeformCoverRatio(item.manga.manga())
             binding.migrationMangaCardTo.setFreeformCoverRatio(null)
 
@@ -88,21 +102,19 @@ class MigrationProcessHolder(
                     }
                 }
 
-                /*launchUI {
-                    item.manga.progress.asFlow().collect { (max, progress) ->
-                        withContext(Dispatchers.Main) {
-                            binding.migrationMangaCardTo.search_progress.let { progressBar ->
-                                progressBar.max = max
-                                progressBar.progress = progress
-                            }
-                        }
-                    }
-                }*/
-
+                // searchResult.get() suspends until the search completes.
+                // This is safe here because bindJob is cancelled on every rebind,
+                // so only one coroutine per holder is ever parked waiting here.
                 val searchResult = item.manga.searchResult.get()?.let { getManga.awaitById(it) }
                 val resultSource = searchResult?.source?.let { sourceManager.get(it) }
+
+                // Guard: if this holder was rebound while we were suspended, bail out.
+                if (!isActive || item.manga.mangaId != this@MigrationProcessHolder.item?.manga?.mangaId) {
+                    return@launch
+                }
+
                 withContext(Dispatchers.Main) {
-                    if (item.manga.mangaId != this@MigrationProcessHolder.item?.manga?.mangaId || item.manga.migrationStatus == MigrationStatus.RUNNUNG) {
+                    if (item.manga.migrationStatus == MigrationStatus.RUNNUNG) {
                         return@withContext
                     }
                     if (searchResult != null && resultSource != null) {
@@ -127,6 +139,14 @@ class MigrationProcessHolder(
                 }
             }
         }
+    }
+
+    /**
+     * Called when this ViewHolder is recycled. Cancels the bind coroutine so
+     * no stale UI updates land on a holder that's been reused for a different item.
+     */
+    fun onRecycled() {
+        bindJob?.cancel()
     }
 
     private fun MangaGridItemBinding.resetManga() {
@@ -178,28 +198,22 @@ class MigrationProcessHolder(
     private fun showPopupMenu(view: View) {
         val item = adapter.getItem(flexibleAdapterPosition) ?: return
 
-        // Create a PopupMenu, giving it the clicked view for an anchor
         val popup = PopupMenu(view.context, view)
-
-        // Inflate our menu resource into the PopupMenu's Menu
         popup.menuInflater.inflate(R.menu.migration_single, popup.menu)
 
         val mangas = item.manga
 
         popup.menu.findItem(R.id.action_search_manually).isVisible = true
-        // Hide download and show delete if the chapter is downloaded
         if (mangas.searchResult.content != null) {
             popup.menu.findItem(R.id.action_migrate_now).isVisible = true
             popup.menu.findItem(R.id.action_copy_now).isVisible = true
         }
 
-        // Set a listener so we are notified if a menu item is clicked
         popup.setOnMenuItemClickListener { menuItem ->
             adapter.menuItemListener.onMenuItemClick(flexibleAdapterPosition, menuItem)
             true
         }
 
-        // Finally show the PopupMenu
         popup.show()
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/util/view/DeferredField.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/view/DeferredField.kt
@@ -20,23 +20,33 @@ class DeferredField<T> {
     private val mutex = Mutex(true)
 
     /**
-     * Initialize the field
+     * Initialize the field. Should only be called once (e.g. when a background search completes).
+     * Calling this more than once is a no-op after the first call.
      */
     fun initialize(content: T) {
+        if (initialized) return  // Guard: already initialized, nothing to do
+
         // Fast-path new listeners
         this.content = content
         initialized = true
 
-        // Notify current listeners
+        // Notify current listeners. The mutex starts locked (Mutex(true)),
+        // so this unlock() will always succeed on first call.
         mutex.unlock()
     }
 
+    /**
+     * Update the field after it has already been initialized (e.g. manual search override).
+     * Safe to call multiple times — uses tryLock() correctly and only unlocks if we won the lock.
+     */
     fun set(content: T) {
-        mutex.tryLock()
+        val locked = mutex.tryLock()  // Returns false if already unlocked (already initialized)
         this.content = content
         initialized = true
-        // Notify current listeners
-        mutex.unlock()
+        // Only unlock if we successfully locked — avoids IllegalStateException
+        // when set() is called after initialize() has already unlocked the mutex,
+        // or when two coroutines race and one of them loses tryLock().
+        if (locked) mutex.unlock()
     }
 
     /**

--- a/app/src/main/java/yokai/data/manga/MangaRepositoryImpl.kt
+++ b/app/src/main/java/yokai/data/manga/MangaRepositoryImpl.kt
@@ -36,8 +36,10 @@ class MangaRepositoryImpl(private val handler: DatabaseHandler) : MangaRepositor
     override suspend fun getLibraryManga(): List<LibraryManga> =
         handler.awaitList { library_viewQueries.findAll(LibraryManga::mapper) }
 
+    // Uses findAllAsFlow which excludes description to avoid CursorWindow overflow
+    // (2MB limit) when the flow re-emits frequently due to background downloads.
     override fun getLibraryMangaAsFlow(): Flow<List<LibraryManga>> =
-        handler.subscribeToList { library_viewQueries.findAll(LibraryManga::mapper) }
+        handler.subscribeToList { library_viewQueries.findAllAsFlow(LibraryManga::flowMapper) }
 
     override suspend fun getDuplicateFavorite(title: String, source: Long): Manga? =
         handler.awaitFirstOrNull { mangasQueries.findDuplicateFavorite(title.lowercase(), source, Manga::mapper) }
@@ -47,7 +49,7 @@ class MangaRepositoryImpl(private val handler: DatabaseHandler) : MangaRepositor
             partialUpdate(update)
             true
         } catch (e: Exception) {
-            Logger.e { "Failed to update manga with id '${update.id}'" }
+            Logger.e(e) { "Failed to update manga with id '${update.id}'" }
             false
         }
     }

--- a/app/src/main/res/values/ids.xml
+++ b/app/src/main/res/values/ids.xml
@@ -2,4 +2,6 @@
 <resources>
 
     <item name="reader_pager" type="id"/>
+    <item name="manga_cover_modified" type="id"/>
+
 </resources>

--- a/data/src/commonMain/sqldelight/tachiyomi/view/library_view.sq
+++ b/data/src/commonMain/sqldelight/tachiyomi/view/library_view.sq
@@ -33,6 +33,40 @@ ON MC.manga_id = M._id
 WHERE M.favorite = 1
 ORDER BY M.title;
 
+-- Full query including description, used for one-shot fetches only.
 findAll:
 SELECT *
+FROM library_view;
+
+-- Lightweight query excluding description for the reactive flow subscription.
+-- Avoids CursorWindow overflow (2MB limit) on large libraries when the flow
+-- re-emits frequently due to background downloads invalidating the chapters table.
+findAllAsFlow:
+SELECT
+    library_view._id,
+    library_view.source,
+    library_view.url,
+    library_view.artist,
+    library_view.author,
+    library_view.genre,
+    library_view.title,
+    library_view.status,
+    library_view.thumbnail_url,
+    library_view.favorite,
+    library_view.last_update,
+    library_view.initialized,
+    library_view.viewer,
+    library_view.hide_title,
+    library_view.chapter_flags,
+    library_view.date_added,
+    library_view.filtered_scanlators,
+    library_view.update_strategy,
+    library_view.cover_last_modified,
+    library_view.total,
+    library_view.has_read,
+    library_view.bookmark_count,
+    library_view.category,
+    library_view.latestUpload,
+    library_view.lastRead,
+    library_view.lastFetch
 FROM library_view;

--- a/i18n/src/commonMain/moko-resources/base/strings.xml
+++ b/i18n/src/commonMain/moko-resources/base/strings.xml
@@ -644,6 +644,7 @@
     <string name="select_sources">Select sources</string>
     <string name="source_migration">Source migration</string>
     <string name="migration">Migration</string>
+    <string name="migrating_progress">Migrating…</string>
     <string name="skip_pre_migration">Skip pre-migration</string>
     <string name="select_a_source_then_item_to_migrate">Select a source, then select an item to
         migrate</string>


### PR DESCRIPTION
Bug Fixes

This PR adds performance improvements, QoL additions, and fixes several bugs found through crash log analysis and testing across the migration UI, library, and manga detail screens.

<details>
<summary>Migration UI Crash (DeferredField)</summary>

**Problem:** `DeferredField.set()` was calling `mutex.tryLock()` but ignoring its return value, then unconditionally calling `mutex.unlock()`. If `initialize()` had already unlocked the mutex before `set()` was called, the second unlock threw `IllegalStateException` and crashed the app during manga source migration.

**Fix:** Store the result of `tryLock()` in a `locked` variable and only call `unlock()` if it returned `true`. Also guard `initialize()` with an early return if already initialized to prevent being called twice.

</details>

<details>
<summary>Migration UI Progressive Slowdown</summary>

**Problem:** `MigrationProcessHolder.bind()` launched a coroutine via `launchUI` that suspended on `searchResult.get()` waiting for a search result. Every `notifyItemChanged()` call after a migration completed would call `bind()` again on every visible holder, launching another suspended coroutine without cancelling the previous one. These accumulated indefinitely on `Dispatchers.Main`, causing the UI to get progressively slower with each migration completed.

**Fix:** Give each holder its own `MainScope` with a tracked `bindJob` that gets cancelled at the start of every `bind()` call, so only one coroutine per holder ever waits at a time. Add `onRecycled()` for clean teardown and wire it up via `onViewRecycled()` in `MigrationProcessAdapter`.

</details>

<details>
<summary>Migration UI Coroutine Scope Cleanup (MigratingManga)</summary>

**Problem:** `MigratingManga` held a bare `CoroutineContext` for `migrationJob` rather than a proper `CoroutineScope`. This meant cancellation wasn't properly propagated to child coroutines, and there was no clean way to cancel all in-flight work for a manga entry.

**Fix:** Replace the bare `CoroutineContext` with a proper `CoroutineScope` (`migrationScope`) backed by a `SupervisorJob`, so one failing source search doesn't cancel sibling searches. Expose a `cancel()` method for clean teardown. Keep `migrationJob` as a property that returns the scope's `coroutineContext` for call sites that need it directly.

</details>

<details>
<summary>Library CursorWindow Overflow (slight mitigation)</summary>

**Partial Fix:** Add a separate `findAllAsFlow` query that explicitly lists all columns except `description`, used only for the reactive flow subscription. The original `findAll` query is preserved for one-shot fetches. A corresponding `flowMapper` was added to `LibraryManga` and `MangaRepositoryImpl` updated to use `findAllAsFlow` with `flowMapper` for the flow subscription.

</details>

<details>
<summary>Manga Description Blank When Opening from Library</summary>

**Problem:** As a consequence of excluding `description` from the library flow, manga objects passed from the library to the detail screen had a `null` description. `MangaDetailsPresenter.onCreate()` only re-fetches from the database if `manga.initialized` is `false`, so it would display no description until a manual refresh.

**Fix:** Add a `manga.description == null` check alongside the existing `!::manga.isInitialized` check in `MangaDetailsPresenter.onCreate()`. If the manga arrives with a `null` description it immediately fetches fresh from the `mangas` table by ID before rendering — a fast single-row lookup.

</details>

<details>
<summary>Library Selection Wiped on Every Chapter Download</summary>

**Problem:** `onNextLibraryUpdate` called `destroyActionModeIfNeeded()` unconditionally on every library flow emission. Since downloads write to the `chapters` table and invalidate the library flow, every chapter download completion wiped the user's entire manga selection in the library.

**Fix:** Make the call conditional — only call `destroyActionModeIfNeeded()` if `selectedMangas` is empty, or if none of the selected manga exist in the updated `mangaMap`. This preserves legitimate cases like selection being cleared after a manga is deleted or filtered out, while leaving selection intact during routine library refreshes.

</details>

<details>
<summary>Chapter List Stutter & Stuck Download Completion Animation</summary>

**Problem:** `downloadManager.queueState` emits the entire global download queue on every
state change for any manga. `onQueueUpdate` originally rebuilt the chapter list (a full DB
read + RecyclerView dataset replacement) on every single emission, causing visible stutter
when other manga were downloading in the background.

A naive fix — early-returning when `queue.none { it.manga.id == mangaId }` — caused a second,
worse bug: the final progress update for a chapter often arrives in the same the download
completes and is removed from the queue, so that check is `true` right when the rebuild is
needed. Left the download button stuck mid-animation, not transitioning to the
completed state, until something else forced an unrelated rebind

**Fix:** Track whether this manga had any queued chapters as of the last emission
(`hadQueuedChapters`). Skip the rebuild only when the manga has no queued chapters now and
had none last time, but always rebuild on the transition from "had queued chapters" to "has
none" — guaranteeing the final completion update is never dropped, while still skipping
emissions for unrelated manga downloading in the background.

</details>

<details>
<summary>Chapter Mark as Read Freeze, Missed Marks, and Start Reading Button</summary>

**Problem:** Three related issues caused by the same root:

- **Freeze (~1 second):** Marking a single chapter as read or bookmarked called `adapter.setChapters()` → `updateDataSet()`, replacing every `ChapterItem` object in the adapter and rebinding the entire list including the manga header with cover art, metadata, genres and description.

- **Missed marks:** The same `updateDataSet()` call replaced all `ChapterItem` objects mid-gesture when swiping rapidly. `FlexibleAdapter`'s swipe recovery would then fire `notifyItemChanged` on the in-progress item, resetting the swipe without completing it — producing a consistent miss rate of roughly 6 in every 20 rapid swipes.

- **Start reading button not updating:** After fixing the above, the start reading button in `MangaHeaderHolder` stopped updating its chapter number since it only refreshes during a full `bind()` call.

**Fix:**
- Add `updateChaptersQuick()` to `MangaDetailsController` — for single chapter marks call `adapter.notifyItemChanged(position)` on just the one affected item, leaving all other `ChapterItem` objects untouched. This eliminates both the freeze and the missed marks. Bulk operations still use the full `updateChapters()`.
- Add a dedicated `updateReadingButton()` method to `MangaHeaderHolder` that only updates the button's text and enabled state based on `getNextUnreadChapter()`, called directly on the live holder instance via `getHeader()` from the controller. Avoids triggering a full header rebind which would cause a visible blink and reintroduce the lag.

</details>


<details>
<summary>Migrate All Progress Dialog</summary>

**Problem:** Clicking Migrate All or Copy All showed no indication that migration was in progress — the screen appeared with no feedback while still being interactable.

**Fix:** Show a non-dismissible progress dialog during `performMigrations` that updates with `current / total` as each manga is migrated. Also refactored `performMigrations` to take a snapshot of items at start for stability, preventing the list changing mid-migration from causing skips or crashes.

</details>

</details>

<details>
<summary>Library Update Spinner Not Animating / Getting Stuck Off</summary>

**Problem:** The per-category update (refresh) icon on the library screen frequently never
started spinning when tapped, or appeared to only start once a manga with an actual update
was found partway through the scan - even though the update was genuinely running the whole
time. With no updates found at all, the icon never spun.

**Root cause:** `LibraryUpdateJob.startNow()` only enqueues a WorkManager job; the job
instance's `categoryIds` set isn't populated until a few lines into `doWork()`. WorkManager
reports the work as `RUNNING` right as `doWork()` starts, before `categoryIds` is filled in.
`LibraryController`'s `isRunningFlow` collector only fires once per state transition, so if
it processed that "now running" event during this gap, every header read
`categoryInQueue() == false` and the spinner never started - and nothing re-checked it again
until an unrelated rebind happened to occur later (most commonly triggered by a manga
actually having new chapters, which is why it looked correlated with "finding an update").

**Fix:** Add `isCategoryUpdating()` to `LibraryCategoryAdapter.LibraryListener`, implemented
in `LibraryController` via a `pendingManualCategoryUpdates` set that's added to the instant a
category update is triggered (single-category tap or global update) and only cleared once
`isRunningFlow` confirms the job has actually stopped. `LibraryHeaderHolder` now checks this
instead of calling `LibraryUpdateJob.categoryInQueue()` directly, so the spinner is immune to
premature/racy rebinds and stays on continuously from tap to genuine completion.

</details>

<details>
<summary>UI Freeze Adding a Category to an Already-Running Library Update</summary>

**Problem:** Tapping a category's update button while a different category's update was
already in progress froze the entire app for several seconds.

**Root cause:** `LibraryUpdateJob.addCategory()` fetched the manga to update via
`runBlocking { getMangaToUpdate(categoryId) }`, which calls `getLibraryManga.await()` - a
full library database fetch. Since `addCategory()` is called from `startNow()`, itself
called directly from the button tap handler on the main thread, `runBlocking` froze the UI
for as long as that query took.

**Note.** Freeze severity likely scales with library size, since addCategory()'s
runBlocking fetch pulls the entire library (not just the target
category) and competes with the running job's own DB activity - small
libraries may not exhibit this noticeably, larger ones more so.

**Fix:** Move `addCategory()`'s work into `extraScope.launch` (already `Dispatchers.IO`
elsewhere in the same class) instead of blocking the calling thread. Also optimized
`isRunning()` to check the in-memory `instance` reference first (set for the exact duration
a job is actually running) before falling back to a blocking WorkManager query, avoiding a
smaller redundant cost on every call from the same process.

</details>

---

### Files Changed

| File | Change |
|------|--------|
| `DeferredField.kt` | Fix `mutex` double-unlock in `set()`, guard `initialize()` against duplicate calls |
| `MigrationProcessHolder.kt` | Per-holder `MainScope` with `bindJob` cancellation, add `onRecycled()` |
| `MigrationProcessAdapter.kt` | Add `onViewRecycled()`, batch snapshot in `performMigrations`, progress callback |
| `MigratingManga.kt` | Replace bare `CoroutineContext` with proper `CoroutineScope`, expose `cancel()` |
| `LibraryController.kt` | Conditional `destroyActionModeIfNeeded()` to preserve selected library manga during background downloads, `isCategoryUpdating()`/`pendingManualCategoryUpdates` for reliable update spinner state |
| `LibraryManga.kt` | Add `flowMapper` excluding `description` for reactive flow subscription |
| `MangaDetailsController.kt` | Add `updateChaptersQuick()` for single chapter updates |
| `MangaDetailsPresenter.kt` | `description == null` check, `hadQueuedChapters` queue-transition tracking in `onQueueUpdate`, `updateChaptersQuick` usage |
| `LibraryHeaderHolder.kt` | Use `isCategoryUpdating()` via listener instead of `LibraryUpdateJob.categoryInQueue()` directly |
| `LibraryCategoryAdapter.kt` | Add `isCategoryUpdating()` to `LibraryListener` interface |
| `LibraryUpdateJob.kt` | Fix UI freeze in `addCategory()` by moving DB fetch off the calling thread, optimize `isRunning()` with in-memory instance check |
| `MangaHeaderHolder.kt` | Add `updateReadingButton()` for targeted button text update without full rebind |
| `library_view.sq` | Add `findAllAsFlow` query excluding `description` |
| `MangaRepositoryImpl.kt` | Use `findAllAsFlow` with `flowMapper` for flow subscription, fix `Logger.e(e)` |
| `MigrationListController.kt` | Add migrate all / copy all progress dialog for migrations screen |
| `strings.xml` | Add `migrating_progress` string |
| `LibraryGridHolder.kt` | Skip cover reload when cover unchanged to prevent thumbnail blink on resume |
| `ids.xml` | Add `manga_cover_modified` resource ID |


Closes #634

Fixes #595


---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/null2264/yokai/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
