### PR TITLE
fix(reader): Preload adjacent chapters when current chapter has a single page

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewer.kt
@@ -73,11 +73,6 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
                 awaitingIdleViewerChapters?.let { viewerChapters ->
                     setChaptersDoubleShift(viewerChapters)
                     awaitingIdleViewerChapters = null
-                    if (viewerChapters.currChapter.pages?.size == 1) {
-                        adapter.nextTransition?.to?.let {
-                            activity.requestPreloadChapter(it)
-                        }
-                    }
                 }
             }
         }
@@ -316,6 +311,15 @@ abstract class PagerViewer(val activity: ReaderActivity) : BaseViewer {
         pager.addOnPageChangeListener(pagerListener)
         // Since we removed the listener while shifting, call page change to update the ui
         onPageChange(pager.currentItem)
+
+        // When the current chapter has a single page, the forward/backward preload that is normally
+        // triggered by scrolling onto a transition page never happens because the lone page settles
+        // at idle. Preload the adjacent chapters here so the user can swipe out of the chapter in
+        // either direction (see issue #617).
+        if (chapters.currChapter.pages?.size == 1) {
+            adapter.prevTransition?.to?.let { activity.requestPreloadChapter(it) }
+            adapter.nextTransition?.to?.let { activity.requestPreloadChapter(it) }
+        }
     }
 
     fun updateShifting(page: ReaderPage? = null) {

--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/viewer/pager/PagerViewerAdapter.kt
@@ -30,7 +30,16 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
     /** Single list of items */
     private var subItems: MutableList<ReaderItem> = mutableListOf()
 
+    /**
+     * Cached chapter-transition references. These always describe the chapter pair on either side
+     * of the current chapter, but they are NOT guaranteed to be present in [joinedItems] (e.g. a
+     * prev/next chapter that is already loaded is skipped and never added as a transition item).
+     * Use them to look up the adjacent chapter, not to assume a transition page is displayed.
+     */
     var nextTransition: ChapterTransition.Next? = null
+        private set
+
+    var prevTransition: ChapterTransition.Prev? = null
         private set
 
     /** Page used to start the shifted pages */
@@ -74,9 +83,12 @@ class PagerViewerAdapter(private val viewer: PagerViewer) : ViewPagerAdapter() {
         }
 
         // Skip transition page if the chapter is loaded & current page is not a transition page
-        if (prevHasMissingChapters || forceTransition || chapters.prevChapter?.state !is ReaderChapter.State.Loaded) {
-            newItems.add(ChapterTransition.Prev(chapters.currChapter, chapters.prevChapter))
-        }
+        prevTransition = ChapterTransition.Prev(chapters.currChapter, chapters.prevChapter)
+            .also {
+                if (prevHasMissingChapters || forceTransition || chapters.prevChapter?.state !is ReaderChapter.State.Loaded) {
+                    newItems.add(it)
+                }
+            }
 
         // Add current chapter.
         val currPages = chapters.currChapter.pages


### PR DESCRIPTION
Closes #617

## Summary

When a chapter consists of exactly one page, the reader never scrolls onto a `ChapterTransition` page, so the adjacent-chapter preload that the transition page normally triggers never runs. Because the lone page settles at idle with the same first/last index, swiping backwards out of the 1-page chapter cannot reach a loaded previous chapter, leaving the reader stuck (the forward direction was already handled, but only for the *next* chapter).

## Changes

- **`PagerViewerAdapter.kt`**: Track a `prevTransition` (`ChapterTransition.Prev`) mirroring the existing `nextTransition`, so the previous-adjacent chapter is reachable for inspection.
- **`PagerViewer.kt`**: Move the single-page adjacent-chapter preload out of the `isIdle`-only path into `setChaptersDoubleShift` so it runs regardless of which code path sets the chapters, and preload the **previous** chapter in addition to the next one.

This lets the user swipe out of a 1-page chapter in either direction, since the preceding chapter is preloaded and the "Load Previous Chapter" transition can proceed.

## Notes

- The previous fix in commit `1040eccd7e "Fix chapter transition setting for one page chapters"` only preloaded `nextTransition?.to`, and only when chapters arrived while the pager was non-idle. This regressed for the backward direction and for the idle path.
- Builds on top of the existing preload mechanism (`requestPreloadChapter` -> `ReaderViewModel.preload` -> `Event.ReloadViewerChapters`), so once the previous chapter loads the viewer is updated as usual.

## Testing

Manual repro from the issue: open a manga, ensure the previous chapter has exactly 1 page, read the current chapter, swipe back into the 1-page chapter, then swipe back again. The reader should now trigger the "Load Previous Chapter" transition instead of getting stuck. Build/CI verification via `./gradlew assembleStandardRelease` + unit tests.