### PR TITLE
fix(extensions): fetch Keiyoushi index.pb catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 
 ### Additions
+- Add support for extension-lib 1.6 (`KeiSource`) extensions (#643) (@mFontecchio)
 - Add random library sort
 - Add the ability to save search queries
 - Add toggle to enable/disable hide source on swipe (@Hiirbaf)
@@ -31,6 +32,8 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Show FAB button to read/resume chapter when start/continue reading button is off-screen
 - LocalSource entries no longer auto-refresh when opened (@lalalasupa0)
 - Long tap chapters on Reader now mark it as read (@lalalasupa0)
+- Fetch manga details and chapters together via `getMangaUpdate` for extension-lib 1.6 compatibility (@mFontecchio)
+- Accept extension repo URLs in more formats (base URL, `index.min.json`, `index.json`, `index.pb`, GitHub raw URLs) (@mFontecchio)
 
 ### Fixes
 - Allow users to bypass onboarding's permission step if Shizuku is installed
@@ -49,7 +52,10 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Fix extension download stuck on pending state
 - Only solve Cloudflare with WebView if it's not geoblock (@AwkwardPeak7)
 - Fix cover from LocalSource sometimes didn't load (@lalalasupa0)
-- Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656)
+- Fix Keiyoushi extension repo (`index.pb`) being rejected as invalid (@mFontecchio)
+- Fix extension repo add failures not showing an error message (@mFontecchio)
+- Fix `CompressionInterceptor` crash when using extension-lib 1.6 sources (e.g. MangaPlus) (@mFontecchio)
+- Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656) (@mFontecchio)
   - Fetch gzipped protobuf `index.pb` (with `index.min.json` fallback for legacy repos)
 
 ### Translation
@@ -80,7 +86,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update dependency org.jetbrains.kotlinx:kotlinx-collections-immutable to v0.4.0
 - Update dependency io.mockk:mockk to v1.14.2
 - Update dependency io.coil-kt.coil3:coil-bom to v3.4.0
-- Update dependency com.squareup.okio:okio to v3.12.0
+- Update dependency com.squareup.okio:okio to v3.18.0 (@mFontecchio)
 - Update dependency com.google.firebase:firebase-bom to v33.14.0
 - Update dependency com.google.accompanist:accompanist-themeadapter-material3 to v0.36.0
 - Update dependency com.github.requery:sqlite-android to v3.49.0
@@ -96,7 +102,8 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update aboutlibraries to v13.1.0
 - Update plugin kotlinter to v5.1.0
 - Update plugin gradle-versions to v0.52.0
-- Update okhttp monorepo to v5.0.0-alpha.16
+- Update okhttp monorepo to v5.4.0 (@mFontecchio)
+  - Add okhttp-zstd
 - Update moko to v0.25.1
 - Update dependency org.jetbrains.kotlinx:kotlinx-coroutines-bom to v1.10.2
 - Update dependency me.zhanghai.android.libarchive:library to v1.1.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Fix extension download stuck on pending state
 - Only solve Cloudflare with WebView if it's not geoblock (@AwkwardPeak7)
 - Fix cover from LocalSource sometimes didn't load (@lalalasupa0)
+- Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656)
+  - Fetch gzipped protobuf `index.pb` (with `index.min.json` fallback for legacy repos)
 
 ### Translation
 - Update translations from Weblate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 
 ### Additions
-- Add support for extension-lib 1.6 (`KeiSource`) extensions (#643) (@mFontecchio)
 - Add random library sort
 - Add the ability to save search queries
 - Add toggle to enable/disable hide source on swipe (@Hiirbaf)
@@ -32,8 +31,6 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Show FAB button to read/resume chapter when start/continue reading button is off-screen
 - LocalSource entries no longer auto-refresh when opened (@lalalasupa0)
 - Long tap chapters on Reader now mark it as read (@lalalasupa0)
-- Fetch manga details and chapters together via `getMangaUpdate` for extension-lib 1.6 compatibility (@mFontecchio)
-- Accept extension repo URLs in more formats (base URL, `index.min.json`, `index.json`, `index.pb`, GitHub raw URLs) (@mFontecchio)
 
 ### Fixes
 - Allow users to bypass onboarding's permission step if Shizuku is installed
@@ -52,11 +49,6 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Fix extension download stuck on pending state
 - Only solve Cloudflare with WebView if it's not geoblock (@AwkwardPeak7)
 - Fix cover from LocalSource sometimes didn't load (@lalalasupa0)
-- Fix Keiyoushi extension repo (`index.pb`) being rejected as invalid (@mFontecchio)
-- Fix extension repo add failures not showing an error message (@mFontecchio)
-- Fix `CompressionInterceptor` crash when using extension-lib 1.6 sources (e.g. MangaPlus) (@mFontecchio)
-- Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656) (@mFontecchio)
-  - Fetch gzipped protobuf `index.pb` (with `index.min.json` fallback for legacy repos)
 
 ### Translation
 - Update translations from Weblate
@@ -86,7 +78,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update dependency org.jetbrains.kotlinx:kotlinx-collections-immutable to v0.4.0
 - Update dependency io.mockk:mockk to v1.14.2
 - Update dependency io.coil-kt.coil3:coil-bom to v3.4.0
-- Update dependency com.squareup.okio:okio to v3.18.0 (@mFontecchio)
+- Update dependency com.squareup.okio:okio to v3.12.0
 - Update dependency com.google.firebase:firebase-bom to v33.14.0
 - Update dependency com.google.accompanist:accompanist-themeadapter-material3 to v0.36.0
 - Update dependency com.github.requery:sqlite-android to v3.49.0
@@ -102,8 +94,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update aboutlibraries to v13.1.0
 - Update plugin kotlinter to v5.1.0
 - Update plugin gradle-versions to v0.52.0
-- Update okhttp monorepo to v5.4.0 (@mFontecchio)
-  - Add okhttp-zstd
+- Update okhttp monorepo to v5.0.0-alpha.16
 - Update moko to v0.25.1
 - Update dependency org.jetbrains.kotlinx:kotlinx-coroutines-bom to v1.10.2
 - Update dependency me.zhanghai.android.libarchive:library to v1.1.5
@@ -122,6 +113,27 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update dependency com.google.android.material:material to v1.14.0-alpha09
 - Update dependency androidx.compose.material3:material3 to v1.5.0-alpha14
 - Minimize memory usage by reducing in-memory cover cache size (@Lolle2000la)
+
+## [1.9.7.6]
+
+### Additions
+- Add support for extension-lib 1.6 (`KeiSource`) extensions (#643) (@mFontecchio)
+
+### Changes
+- Fetch manga details and chapters together via `getMangaUpdate` for extension-lib 1.6 compatibility (@mFontecchio)
+- Accept extension repo URLs in more formats (base URL, `index.min.json`, `index.json`, `index.pb`, GitHub raw URLs) (@mFontecchio)
+
+### Fixes
+- Fix Keiyoushi extension repo (`index.pb`) being rejected as invalid (@mFontecchio)
+- Fix extension repo add failures not showing an error message (@mFontecchio)
+- Fix `CompressionInterceptor` crash when using extension-lib 1.6 sources (e.g. MangaPlus) (@mFontecchio)
+- Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656) (@mFontecchio)
+  - Fetch gzipped protobuf `index.pb` (with `index.min.json` fallback for legacy repos)
+
+### Other
+- Update okhttp monorepo to v5.4.0 (@mFontecchio)
+  - Add okhttp-zstd
+- Update dependency com.squareup.okio:okio to v3.18.0 (@mFontecchio)
 
 ## [1.9.7.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,11 +127,14 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Fix `CompressionInterceptor` crash when using extension-lib 1.6 sources (e.g. MangaPlus) (@mFontecchio)
 - Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656) (@mFontecchio)
   - Fetch gzipped protobuf `index.pb` (with `index.min.json` fallback for legacy repos)
+- Fix `AbstractMethodError` (`GeneratedSerializer.typeParametersSerializers`) when browsing current Keiyoushi extensions (e.g. Pawchive) (#663) (@mFontecchio)
 
 ### Other
 - Update okhttp monorepo to v5.4.0 (@mFontecchio)
   - Add okhttp-zstd
 - Update dependency com.squareup.okio:okio to v3.18.0 (@mFontecchio)
+- Update kotlinx.serialization to v1.11.0 (align with Mihon/Keiyoushi) (@mFontecchio)
+- Update kotlin monorepo to v2.3.20 (@mFontecchio)
 
 ## [1.9.7.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 
 ### Additions
+- Add support for extension-lib 1.6 (`KeiSource`) extensions (#643) (@mFontecchio)
 - Add random library sort
 - Add the ability to save search queries
 - Add toggle to enable/disable hide source on swipe (@Hiirbaf)
@@ -31,6 +32,8 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Show FAB button to read/resume chapter when start/continue reading button is off-screen
 - LocalSource entries no longer auto-refresh when opened (@lalalasupa0)
 - Long tap chapters on Reader now mark it as read (@lalalasupa0)
+- Fetch manga details and chapters together via `getMangaUpdate` for extension-lib 1.6 compatibility (@mFontecchio)
+- Accept extension repo URLs in more formats (base URL, `index.min.json`, `index.json`, `index.pb`, GitHub raw URLs) (@mFontecchio)
 
 ### Fixes
 - Allow users to bypass onboarding's permission step if Shizuku is installed
@@ -49,6 +52,11 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Fix extension download stuck on pending state
 - Only solve Cloudflare with WebView if it's not geoblock (@AwkwardPeak7)
 - Fix cover from LocalSource sometimes didn't load (@lalalasupa0)
+- Fix Keiyoushi extension repo (`index.pb`) being rejected as invalid (@mFontecchio)
+- Fix extension repo add failures not showing an error message (@mFontecchio)
+- Fix `CompressionInterceptor` crash when using extension-lib 1.6 sources (e.g. MangaPlus) (@mFontecchio)
+- Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656) (@mFontecchio)
+  - Fetch gzipped protobuf `index.pb` (with `index.min.json` fallback for legacy repos)
 
 ### Translation
 - Update translations from Weblate
@@ -78,7 +86,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update dependency org.jetbrains.kotlinx:kotlinx-collections-immutable to v0.4.0
 - Update dependency io.mockk:mockk to v1.14.2
 - Update dependency io.coil-kt.coil3:coil-bom to v3.4.0
-- Update dependency com.squareup.okio:okio to v3.12.0
+- Update dependency com.squareup.okio:okio to v3.18.0 (@mFontecchio)
 - Update dependency com.google.firebase:firebase-bom to v33.14.0
 - Update dependency com.google.accompanist:accompanist-themeadapter-material3 to v0.36.0
 - Update dependency com.github.requery:sqlite-android to v3.49.0
@@ -94,7 +102,8 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update aboutlibraries to v13.1.0
 - Update plugin kotlinter to v5.1.0
 - Update plugin gradle-versions to v0.52.0
-- Update okhttp monorepo to v5.0.0-alpha.16
+- Update okhttp monorepo to v5.4.0 (@mFontecchio)
+  - Add okhttp-zstd
 - Update moko to v0.25.1
 - Update dependency org.jetbrains.kotlinx:kotlinx-coroutines-bom to v1.10.2
 - Update dependency me.zhanghai.android.libarchive:library to v1.1.5
@@ -113,27 +122,6 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update dependency com.google.android.material:material to v1.14.0-alpha09
 - Update dependency androidx.compose.material3:material3 to v1.5.0-alpha14
 - Minimize memory usage by reducing in-memory cover cache size (@Lolle2000la)
-
-## [1.9.7.6]
-
-### Additions
-- Add support for extension-lib 1.6 (`KeiSource`) extensions (#643) (@mFontecchio)
-
-### Changes
-- Fetch manga details and chapters together via `getMangaUpdate` for extension-lib 1.6 compatibility (@mFontecchio)
-- Accept extension repo URLs in more formats (base URL, `index.min.json`, `index.json`, `index.pb`, GitHub raw URLs) (@mFontecchio)
-
-### Fixes
-- Fix Keiyoushi extension repo (`index.pb`) being rejected as invalid (@mFontecchio)
-- Fix extension repo add failures not showing an error message (@mFontecchio)
-- Fix `CompressionInterceptor` crash when using extension-lib 1.6 sources (e.g. MangaPlus) (@mFontecchio)
-- Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656) (@mFontecchio)
-  - Fetch gzipped protobuf `index.pb` (with `index.min.json` fallback for legacy repos)
-
-### Other
-- Update okhttp monorepo to v5.4.0 (@mFontecchio)
-  - Add okhttp-zstd
-- Update dependency com.squareup.okio:okio to v3.18.0 (@mFontecchio)
 
 ## [1.9.7.5]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 
 ### Additions
-- Add support for extension-lib 1.6 (`KeiSource`) extensions (#643) (@mFontecchio)
 - Add random library sort
 - Add the ability to save search queries
 - Add toggle to enable/disable hide source on swipe (@Hiirbaf)
@@ -32,8 +31,6 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Show FAB button to read/resume chapter when start/continue reading button is off-screen
 - LocalSource entries no longer auto-refresh when opened (@lalalasupa0)
 - Long tap chapters on Reader now mark it as read (@lalalasupa0)
-- Fetch manga details and chapters together via `getMangaUpdate` for extension-lib 1.6 compatibility (@mFontecchio)
-- Accept extension repo URLs in more formats (base URL, `index.min.json`, `index.json`, `index.pb`, GitHub raw URLs) (@mFontecchio)
 
 ### Fixes
 - Allow users to bypass onboarding's permission step if Shizuku is installed
@@ -52,11 +49,6 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Fix extension download stuck on pending state
 - Only solve Cloudflare with WebView if it's not geoblock (@AwkwardPeak7)
 - Fix cover from LocalSource sometimes didn't load (@lalalasupa0)
-- Fix Keiyoushi extension repo (`index.pb`) being rejected as invalid (@mFontecchio)
-- Fix extension repo add failures not showing an error message (@mFontecchio)
-- Fix `CompressionInterceptor` crash when using extension-lib 1.6 sources (e.g. MangaPlus) (@mFontecchio)
-- Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656) (@mFontecchio)
-  - Fetch gzipped protobuf `index.pb` (with `index.min.json` fallback for legacy repos)
 
 ### Translation
 - Update translations from Weblate
@@ -86,7 +78,6 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update dependency org.jetbrains.kotlinx:kotlinx-collections-immutable to v0.4.0
 - Update dependency io.mockk:mockk to v1.14.2
 - Update dependency io.coil-kt.coil3:coil-bom to v3.4.0
-- Update dependency com.squareup.okio:okio to v3.18.0 (@mFontecchio)
 - Update dependency com.google.firebase:firebase-bom to v33.14.0
 - Update dependency com.google.accompanist:accompanist-themeadapter-material3 to v0.36.0
 - Update dependency com.github.requery:sqlite-android to v3.49.0
@@ -102,8 +93,6 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update aboutlibraries to v13.1.0
 - Update plugin kotlinter to v5.1.0
 - Update plugin gradle-versions to v0.52.0
-- Update okhttp monorepo to v5.4.0 (@mFontecchio)
-  - Add okhttp-zstd
 - Update moko to v0.25.1
 - Update dependency org.jetbrains.kotlinx:kotlinx-coroutines-bom to v1.10.2
 - Update dependency me.zhanghai.android.libarchive:library to v1.1.5
@@ -122,6 +111,27 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 - Update dependency com.google.android.material:material to v1.14.0-alpha09
 - Update dependency androidx.compose.material3:material3 to v1.5.0-alpha14
 - Minimize memory usage by reducing in-memory cover cache size (@Lolle2000la)
+
+## [1.10.1]
+
+### Additions
+- Add support for extension-lib 1.6 (`KeiSource`) extensions (#643) (@mFontecchio)
+
+### Changes
+- Fetch manga details and chapters together via `getMangaUpdate` for extension-lib 1.6 compatibility (@mFontecchio)
+- Accept extension repo URLs in more formats (base URL, `index.min.json`, `index.json`, `index.pb`, GitHub raw URLs) (@mFontecchio)
+
+### Fixes
+- Fix Keiyoushi extension repo (`index.pb`) being rejected as invalid (@mFontecchio)
+- Fix extension repo add failures not showing an error message (@mFontecchio)
+- Fix `CompressionInterceptor` crash when using extension-lib 1.6 sources (e.g. MangaPlus) (@mFontecchio)
+- Fix Keiyoushi extension catalog empty / all extensions marked obsolete after `index.min.json` was stubbed (#659, #656) (@mFontecchio)
+  - Fetch gzipped protobuf `index.pb` (with `index.min.json` fallback for legacy repos)
+
+### Other
+- Update okhttp monorepo to v5.4.0 (@mFontecchio)
+  - Add okhttp-zstd
+- Update dependency com.squareup.okio:okio to v3.18.0 (@mFontecchio)
 
 ## [1.9.7.5]
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ fun runCommand(command: String): String {
 }
 
 @Suppress("PropertyName")
-val _versionName = "1.9.7.6"
+val _versionName = "1.10.0"
 val betaCount by lazy {
     val betaTags = runCommand("git tag -l --sort=refname v${_versionName}-b*")
 
@@ -50,7 +50,7 @@ val supportedAbis = setOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
 android {
     defaultConfig {
         applicationId = "eu.kanade.tachiyomi"
-        versionCode = 159
+        versionCode = 158
         versionName = _versionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ fun runCommand(command: String): String {
 }
 
 @Suppress("PropertyName")
-val _versionName = "1.10.0"
+val _versionName = "1.10.1"
 val betaCount by lazy {
     val betaTags = runCommand("git tag -l --sort=refname v${_versionName}-b*")
 
@@ -50,7 +50,7 @@ val supportedAbis = setOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
 android {
     defaultConfig {
         applicationId = "eu.kanade.tachiyomi"
-        versionCode = 158
+        versionCode = 159
         versionName = _versionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -27,7 +27,7 @@ fun runCommand(command: String): String {
 }
 
 @Suppress("PropertyName")
-val _versionName = "1.10.0"
+val _versionName = "1.9.7.6"
 val betaCount by lazy {
     val betaTags = runCommand("git tag -l --sort=refname v${_versionName}-b*")
 
@@ -50,7 +50,7 @@ val supportedAbis = setOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
 android {
     defaultConfig {
         applicationId = "eu.kanade.tachiyomi"
-        versionCode = 158
+        versionCode = 159
         versionName = _versionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         multiDexEnabled = true

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -62,6 +62,18 @@
 -keepclasseswithmembers class okhttp3.MultipartBody$Builder { *; }
 ##---------------End: proguard configuration for okhttp  ----------
 
+# zstd-kmp (via okhttp-zstd) — used by extension-lib 1.6 CompressionInterceptor.
+# Native libzstd-kmp.so is packaged, but R8 strips Java/JNI classes in release/nightly
+# because the host never calls them directly (extensions do at runtime). Without these
+# keeps, FindClass(ZstdCompressor) aborts the process (SIGABRT).
+# zstd-kmp 0.4.0 ships no consumer ProGuard rules.
+-keep class com.squareup.zstd.** { *; }
+-keepclassmembers class com.squareup.zstd.** {
+    native <methods>;
+    *;
+}
+-dontwarn com.squareup.zstd.**
+
 ##---------------Begin: proguard configuration for kotlinx.serialization  ----------
 -keepattributes *Annotation*, InnerClasses
 -dontnote kotlinx.serialization.AnnotationsKt # core serialization annotations

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionApi.kt
@@ -14,6 +14,11 @@ import eu.kanade.tachiyomi.util.system.withIOContext
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.protobuf.ProtoBuf
+import okio.BufferedSource
+import okio.buffer
+import okio.gzip
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 import uy.kohesive.injekt.injectLazy
@@ -26,6 +31,7 @@ internal class ExtensionApi {
     private val networkService: NetworkHelper by injectLazy()
     private val getExtensionRepo: GetExtensionRepo by injectLazy()
     private val updateExtensionRepo: UpdateExtensionRepo by injectLazy()
+    private val protoBuf: ProtoBuf by injectLazy()
 
     suspend fun findExtensions(): List<Extension.Available> {
         return withIOContext {
@@ -41,17 +47,43 @@ internal class ExtensionApi {
     ): List<Extension.Available> {
         val repoBaseUrl = repo.baseUrl
         return try {
-            val response = networkService.client
-                .newCall(GET("$repoBaseUrl/index.min.json"))
-                .awaitSuccess()
-
-            response
-                .parseAs<List<ExtensionJsonObject>>()
-                .toExtensions(repoBaseUrl)
+            // Prefer protobuf index (Keiyoushi stubbed index.min.json for outdated apps)
+            fetchProtobufExtensions(repoBaseUrl)
+                ?.takeIf { it.isNotEmpty() }
+                ?: fetchJsonExtensions(repoBaseUrl)
         } catch (e: Throwable) {
             Logger.e(e) { "Failed to get extensions from $repoBaseUrl" }
             emptyList()
         }
+    }
+
+    private suspend fun fetchProtobufExtensions(repoBaseUrl: String): List<Extension.Available>? {
+        return try {
+            val response = networkService.client
+                .newCall(GET("$repoBaseUrl/index.pb"))
+                .awaitSuccess()
+
+            response.body.source().decompressIfGzipped().use { source ->
+                protoBuf.decodeFromByteArray<ExtensionIndexDto>(source.readByteArray())
+                    .extensionList
+                    ?.extensions
+                    .orEmpty()
+                    .toAvailableExtensions(repoBaseUrl)
+            }
+        } catch (e: Throwable) {
+            Logger.d(e) { "No protobuf index at $repoBaseUrl, falling back to JSON" }
+            null
+        }
+    }
+
+    private suspend fun fetchJsonExtensions(repoBaseUrl: String): List<Extension.Available> {
+        val response = networkService.client
+            .newCall(GET("$repoBaseUrl/index.min.json"))
+            .awaitSuccess()
+
+        return response
+            .parseAs<List<ExtensionJsonObject>>()
+            .toExtensions(repoBaseUrl)
     }
 
     suspend fun checkForUpdates(context: Context, prefetchedExtensions: List<Extension.Available>? = null): List<Extension.Available> {
@@ -84,6 +116,43 @@ internal class ExtensionApi {
         }
     }
 
+    private fun List<ExtensionIndexDto.Extension>.toAvailableExtensions(repoUrl: String): List<Extension.Available> {
+        return this
+            .mapNotNull { ext ->
+                val libVersion = ext.extensionLib.toDoubleOrNull()
+                    ?: ext.versionName.substringBeforeLast('.').toDoubleOrNull()
+                    ?: return@mapNotNull null
+                if (libVersion < ExtensionLoader.LIB_VERSION_MIN || libVersion > ExtensionLoader.LIB_VERSION_MAX) {
+                    return@mapNotNull null
+                }
+                val resources = ext.resources ?: return@mapNotNull null
+                val apkName = resources.apkUrl.substringAfterLast('/')
+                if (apkName.isEmpty()) return@mapNotNull null
+
+                val languages = ext.sources.map { it.language }.toSet()
+                Extension.Available(
+                    name = ext.name,
+                    pkgName = ext.packageName,
+                    versionName = ext.versionName,
+                    versionCode = ext.versionCode,
+                    libVersion = libVersion,
+                    lang = if (languages.size == 1) languages.first() else "all",
+                    isNsfw = ext.contentWarning >= ExtensionIndexDto.ContentWarning.MIXED,
+                    sources = ext.sources.map { source ->
+                        Extension.AvailableSource(
+                            name = source.name,
+                            id = source.id,
+                            lang = source.language,
+                            baseUrl = source.homeUrl,
+                        )
+                    },
+                    apkName = apkName,
+                    iconUrl = resources.iconUrl.ifEmpty { "$repoUrl/icon/${ext.packageName}.png" },
+                    repoUrl = repoUrl,
+                )
+            }
+    }
+
     private fun List<ExtensionJsonObject>.toExtensions(repoUrl: String): List<Extension.Available> {
         return this
             .filter {
@@ -113,6 +182,17 @@ internal class ExtensionApi {
 
     private fun ExtensionJsonObject.extractLibVersion(): Double {
         return version.substringBeforeLast('.').toDouble()
+    }
+
+    private fun BufferedSource.decompressIfGzipped(): BufferedSource {
+        val isGzip = peek().use { peeked ->
+            try {
+                peeked.readShort().toInt() and 0xFFFF == 0x1f8b
+            } catch (_: Exception) {
+                false
+            }
+        }
+        return if (isGzip) gzip().buffer() else this
     }
 }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionIndexDto.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/api/ExtensionIndexDto.kt
@@ -1,0 +1,70 @@
+package eu.kanade.tachiyomi.extension.api
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
+
+/**
+ * Protobuf schema for Keiyoushi/Mihon `index.pb` extension repositories.
+ * Field numbers must match the repo `Index` message.
+ */
+@Serializable
+data class ExtensionIndexDto(
+    @ProtoNumber(1) val name: String = "",
+    @ProtoNumber(2) val badgeLabel: String = "",
+    @ProtoNumber(3) val signingKey: String = "",
+    @ProtoNumber(4) val contact: Contact? = null,
+    @ProtoNumber(101) val extensionList: ExtensionList? = null,
+    @ProtoNumber(102) val extensionListUrl: String? = null,
+) {
+    @Serializable
+    data class Contact(
+        @ProtoNumber(1) val website: String = "",
+        @ProtoNumber(2) val discord: String? = null,
+    )
+
+    @Serializable
+    data class ExtensionList(
+        @ProtoNumber(1) val extensions: List<Extension> = emptyList(),
+    )
+
+    @Serializable
+    data class Extension(
+        @ProtoNumber(1) val name: String = "",
+        @ProtoNumber(2) val packageName: String = "",
+        @ProtoNumber(3) val resources: Resources? = null,
+        @ProtoNumber(4) val extensionLib: String = "",
+        @ProtoNumber(5) val versionCode: Long = 0,
+        @ProtoNumber(6) val versionName: String = "",
+        @ProtoNumber(7) val contentWarning: ContentWarning = ContentWarning.UNSPECIFIED,
+        @ProtoNumber(8) val sources: List<Source> = emptyList(),
+    )
+
+    @Serializable
+    data class Resources(
+        @ProtoNumber(1) val apkUrl: String = "",
+        @ProtoNumber(2) val iconUrl: String = "",
+    )
+
+    @Serializable
+    data class Source(
+        @ProtoNumber(1) val id: Long = 0,
+        @ProtoNumber(2) val name: String = "",
+        @ProtoNumber(3) val language: String = "",
+        @ProtoNumber(4) val homeUrl: String = "",
+    )
+
+    @Serializable
+    enum class ContentWarning {
+        @ProtoNumber(0)
+        UNSPECIFIED,
+
+        @ProtoNumber(1)
+        SAFE,
+
+        @ProtoNumber(2)
+        MIXED,
+
+        @ProtoNumber(3)
+        NSFW,
+    }
+}

--- a/gradle/kotlinx.versions.toml
+++ b/gradle/kotlinx.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "2.3.10"
-serialization = "1.8.1"
+kotlin = "2.3.20"
+serialization = "1.11.0"
 xml_serialization = "0.91.1"
 
 [libraries]


### PR DESCRIPTION
## Summary
- Prefer gzipped protobuf `index.pb` when listing available extensions, with `index.min.json` fallback for legacy repos
- Restores the Keiyoushi catalog after their Jul 29 repo changes stubbed `index.min.json` for outdated apps
- Fixes empty / obsolete-only extension lists reported in #659 and #656

## Keiyoushi extensions repo context (past day)
Keiyoushi replaced the legacy JSON catalog with a stub that only shows “Outdated App” / “Update to Mihon 0.20.1+”, while the real catalog lives in `index.pb`:

- [923a023](https://github.com/keiyoushi/extensions/commit/923a023) — Remove legacy index (2026-07-29)
- [424f38c](https://github.com/keiyoushi/extensions/commit/424f38c) — Update message for old apps
- [cd469c6](https://github.com/keiyoushi/extensions/commit/cd469c6) — Update message for old apps x2
- Follow-up repo refreshes: [68c3441](https://github.com/keiyoushi/extensions/commit/68c3441), [bfdbd82](https://github.com/keiyoushi/extensions/commit/bfdbd82) (2026-07-30)

Official add-repo URL is now `https://github.com/keiyoushi/extensions/raw/repo/index.pb`.

<img width="320" height="714" alt="image" src="https://github.com/user-attachments/assets/d058d743-6157-4e46-b131-1aa8c1a0396f" />
<img width="320" height="714" alt="image" src="https://github.com/user-attachments/assets/b0ef652b-6bbc-4a05-8f1a-8f2fbdca2f53" />
<img width="320" height="714" alt="image" src="https://github.com/user-attachments/assets/9f6366bb-4c8e-4528-b147-1359d274d1c5" />
<img width="320" height="714" alt="image" src="https://github.com/user-attachments/assets/7fb9af7c-2574-486e-87b5-d960e10a6ab9" />
<img width="320" height="714" alt="image" src="https://github.com/user-attachments/assets/46adcefe-0543-4001-bb42-94315c5c27a6" />
<img width="320" height="714" alt="image" src="https://github.com/user-attachments/assets/0d2996c1-ac7a-4da4-9579-70b364f293c6" />
<img width="320" height="714" alt="image" src="https://github.com/user-attachments/assets/243a0d0f-ac31-4ab0-8745-efaa01a8d4dc" />

---

## Test plan
- [ ] With Keiyoushi repo added, Browse → Extensions shows the full catalog (not only the stub entries)
- [ ] Pull-to-refresh extensions still works
- [ ] Installed extensions are no longer mass-marked obsolete solely because the JSON stub is empty
- [ ] Legacy repos that only publish `index.min.json` still load
- [ ] Install/update an extension from the restored list

Fixes #669 
Fixes #667 
Fixes #665 
Fixes #663 
Fixes #659
Fixes #656
Fixes #652 
Fixes #651 
Fixes #649 
Fixes #648 

---
Nightly Build Artifact: https://github.com/null2264/yokai/actions/runs/30719118606/artifacts/8824437017