### PR TITLE
Fix custom base URL crash

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/extension/details/ExtensionDetailsController.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/extension/details/ExtensionDetailsController.kt
@@ -59,6 +59,13 @@ import uy.kohesive.injekt.injectLazy
 import yokai.i18n.MR
 import yokai.util.lang.getString
 
+internal fun forwardEditTextPreferenceChange(
+    dialog: EditTextResetPreference,
+    source: EditTextPreference,
+) {
+    dialog.onChange { source.callChangeListener(it) }
+}
+
 @SuppressLint("RestrictedApi")
 class ExtensionDetailsController(bundle: Bundle? = null) :
     BaseCoroutineController<ExtensionDetailControllerBinding, ExtensionDetailsPresenter>(bundle),
@@ -302,7 +309,7 @@ class ExtensionDetailsController(bundle: Bundle? = null) :
         val matPref = when (preference) {
             is EditTextPreference -> EditTextResetPreference(activity, context).apply {
                 dialogSummary = preference.dialogMessage
-                onPreferenceChangeListener = preference.onPreferenceChangeListener
+                forwardEditTextPreferenceChange(this, preference)
             }
 
             is ListPreference -> ListMatPreference(activity, context).apply {

--- a/app/src/test/java/eu/kanade/tachiyomi/ui/extension/details/ExtensionDetailsControllerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/ui/extension/details/ExtensionDetailsControllerTest.kt
@@ -1,0 +1,44 @@
+package eu.kanade.tachiyomi.ui.extension.details
+
+import androidx.preference.EditTextPreference
+import androidx.preference.Preference
+import eu.kanade.tachiyomi.widget.preference.EditTextResetPreference
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class ExtensionDetailsControllerTest {
+    @Test
+    fun `edit text dialog forwards accepted change to source preference`() {
+        val source = mockk<EditTextPreference>()
+        val dialog = mockk<EditTextResetPreference>()
+        val listener = slot<Preference.OnPreferenceChangeListener>()
+        every { dialog.setOnPreferenceChangeListener(capture(listener)) } just Runs
+        every { source.callChangeListener("https://example.com/2") } returns true
+
+        forwardEditTextPreferenceChange(dialog, source)
+
+        assertTrue(listener.captured.onPreferenceChange(dialog, "https://example.com/2"))
+        verify(exactly = 1) { source.callChangeListener("https://example.com/2") }
+    }
+
+    @Test
+    fun `edit text dialog propagates rejected change`() {
+        val source = mockk<EditTextPreference>()
+        val dialog = mockk<EditTextResetPreference>()
+        val listener = slot<Preference.OnPreferenceChangeListener>()
+        every { dialog.setOnPreferenceChangeListener(capture(listener)) } just Runs
+        every { source.callChangeListener("invalid") } returns false
+
+        forwardEditTextPreferenceChange(dialog, source)
+
+        assertFalse(listener.captured.onPreferenceChange(dialog, "invalid"))
+        verify(exactly = 1) { source.callChangeListener("invalid") }
+    }
+}


### PR DESCRIPTION
The edit-text dialog now calls the source preference's change listener instead of reusing a listener that casts the dialog to EditTextPreference. This prevents the ClassCastException and preserves accepted and rejected listener results. Tests: testStandardReleaseUnitTest (18 passed). Closes #640.