### PR TITLE
fix: Remember double page shift in auto pager mode

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/ui/reader/ReaderActivity.kt
@@ -503,10 +503,10 @@ class ReaderActivity : BaseActivity<ReaderActivityBinding>() {
         outState.putBoolean(::menuVisible.name, menuVisible)
         (viewer as? PagerViewer)?.let { pViewer ->
             val config = pViewer.config
-            if (config.doublePages) {
+            if (config.doublePages || config.autoDoublePages) {
                 outState.putBoolean(SHIFT_DOUBLE_PAGES, config.shiftDoublePage)
             }
-            if (config.shiftDoublePage && config.doublePages) {
+            if (config.shiftDoublePage && (config.doublePages || config.autoDoublePages)) {
                 pViewer.getShiftedPage()?.let {
                     outState.putInt(SHIFTED_PAGE_INDEX, it.index)
                     outState.putLong(SHIFTED_CHAP_INDEX, it.chapter.chapter.id ?: 0L)


### PR DESCRIPTION
<!--
^ Please summarise the changes you have made here ^
-->

---
# Summary

When using "Automatic" page layout, the "Shift Double Page" option doesn't persist across orientation changes. It means you cannot comfortably read in portrait mode and switch to landscape only for double page spreads, which is my main use case for the auto mode.

The same issue was reported and discarded in the upstream a long time ago: https://github.com/Jays2Kings/tachiyomiJ2K/issues/1654

# Steps to reproduce
- Open file in portrait mode
- Change orientation to landscape
- Bring up the bottom menu bar
- Click the Shift Double Page option
- Pages are shifted properly
- Change orientation to portrait
- Change orientation to landscape
- Pages are not shifted properly anymore

# Extra info
- Affected version: 1.9.7.5
- Fix tested on: Onyx Boox NoteAir3C
- The fix is very basic and doesn't survive reader exit, but it's a step in the right direction IMO.