### PR TITLE
fix: use local URI for completed extension downloads

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionInstaller.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/extension/util/ExtensionInstaller.kt
@@ -448,27 +448,29 @@ internal class ExtensionInstaller(private val context: Context) {
             // Avoid events for downloads we didn't request
             if (id !in activeDownloads.values) return
 
-            val uri = downloadManager.getUriForDownloadedFile(id)
-
-            val pkgName = activeDownloads.entries.find { id == it.value }?.key
-            // Set next installation step
-            if (uri != null && pkgName != null) {
-                emitToFlow(pkgName, ExtensionIntallInfo(InstallStep.Loading, null))
-            } else if (pkgName != null) {
-                Logger.e { "Couldn't locate downloaded APK" }
-                emitToFlow(pkgName, ExtensionIntallInfo(InstallStep.Error, null))
-                return
-            }
-
+            val pkgName = activeDownloads.entries.find { id == it.value }?.key ?: return
             val query = DownloadManager.Query().setFilterById(id)
             downloadManager.query(query).use { cursor ->
-                if (cursor.moveToFirst()) {
-                    val localUri = cursor.getString(
-                        cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI),
-                    ).removePrefix(FILE_SCHEME)
-
-                    installApk(id, File(localUri).getUriCompat(context))
+                if (!cursor.moveToFirst()) {
+                    Logger.e { "Downloaded extension row was unavailable" }
+                    emitToFlow(pkgName, ExtensionIntallInfo(InstallStep.Error, null))
+                    return
                 }
+
+                val status = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_STATUS))
+                val reason = cursor.getInt(cursor.getColumnIndex(DownloadManager.COLUMN_REASON))
+                val localUri = completedDownloadUri(
+                    status,
+                    cursor.getString(cursor.getColumnIndex(DownloadManager.COLUMN_LOCAL_URI)),
+                )
+                if (localUri == null) {
+                    Logger.e { "Couldn't locate downloaded APK: status=$status reason=$reason" }
+                    emitToFlow(pkgName, ExtensionIntallInfo(InstallStep.Error, null))
+                    return
+                }
+
+                emitToFlow(pkgName, ExtensionIntallInfo(InstallStep.Loading, null))
+                installApk(id, File(localUri.removePrefix(FILE_SCHEME)).getUriCompat(context))
             }
         }
     }
@@ -478,4 +480,8 @@ internal class ExtensionInstaller(private val context: Context) {
         const val EXTRA_DOWNLOAD_ID = "ExtensionInstaller.extra.DOWNLOAD_ID"
         const val FILE_SCHEME = "file://"
     }
+}
+
+internal fun completedDownloadUri(status: Int, localUri: String?): String? {
+    return localUri?.takeIf { status == DownloadManager.STATUS_SUCCESSFUL && it.isNotBlank() }
 }

--- a/app/src/test/java/eu/kanade/tachiyomi/extension/util/ExtensionInstallerTest.kt
+++ b/app/src/test/java/eu/kanade/tachiyomi/extension/util/ExtensionInstallerTest.kt
@@ -1,0 +1,20 @@
+package eu.kanade.tachiyomi.extension.util
+
+import android.app.DownloadManager
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+
+class ExtensionInstallerTest {
+    @Test
+    fun `completed download retains its local uri`() {
+        val uri = "file:///tmp/extension.apk"
+
+        assertEquals(uri, completedDownloadUri(DownloadManager.STATUS_SUCCESSFUL, uri))
+    }
+
+    @Test
+    fun `failed download does not return a local uri`() {
+        assertNull(completedDownloadUri(DownloadManager.STATUS_FAILED, "file:///tmp/extension.apk"))
+    }
+}


### PR DESCRIPTION
Fixes #683.

Use the completed download row local URI after checking for a successful download.

Tests: `./gradlew :app:testDevDebugUnitTest`