### PR TITLE
fix: persist extension-lib 1.6 memo so v1.6 chapters can open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 
 ## [Unreleased]
 
+### Fixes
+- Persist extension-lib 1.6 source `memo` so chapters from sources like Asura, Kayn, Vortex, and Hive can open after a refresh (#691)
+
 ## [1.10.0]
 
 ### Additions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is simplified version of [Keep a Changelog](https://keepachangelog.co
 ## [Unreleased]
 
 ### Fixes
-- Persist extension-lib 1.6 source `memo` so chapters from sources like Asura, Kayn, Vortex, and Hive can open after a refresh (#691)
+- Add missing `memo` column for extension-lib 1.6 (#691) (@mFontecchio)
 
 ## [1.10.0]
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupChapter.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.backup.models
 
 import eu.kanade.tachiyomi.data.database.models.ChapterImpl
+import eu.kanade.tachiyomi.source.model.decodeMemoBytes
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
 
@@ -20,6 +21,8 @@ data class BackupChapter(
     // chapterNumber is called number is 1.x
     @ProtoNumber(9) var chapterNumber: Float = 0F,
     @ProtoNumber(10) var sourceOrder: Int = 0,
+    // Matches Mihon for extension-lib 1.6 memo
+    @ProtoNumber(13) var memo: ByteArray = ByteArray(0),
 
     // J2K specific values
     @ProtoNumber(800) var pagesLeft: Int = 0,
@@ -37,6 +40,7 @@ data class BackupChapter(
             date_upload = this@BackupChapter.dateUpload
             source_order = this@BackupChapter.sourceOrder
             pages_left = this@BackupChapter.pagesLeft
+            memo = this@BackupChapter.memo.decodeMemoBytes()
         }
     }
 
@@ -55,6 +59,7 @@ data class BackupChapter(
             sourceOrder: Long,
             dateFetch: Long,
             dateUpload: Long,
+            memo: String,
         ) = BackupChapter(
             url = url,
             name = name,
@@ -67,6 +72,7 @@ data class BackupChapter(
             sourceOrder = sourceOrder.toInt(),
             dateFetch = dateFetch,
             dateUpload = dateUpload,
+            memo = memo.encodeToByteArray(),
         )
     }
 }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/backup/models/BackupManga.kt
@@ -7,6 +7,9 @@ import eu.kanade.tachiyomi.data.database.models.readingModeType
 import eu.kanade.tachiyomi.data.library.CustomMangaManager
 import eu.kanade.tachiyomi.domain.manga.models.Manga
 import eu.kanade.tachiyomi.source.model.UpdateStrategy
+import eu.kanade.tachiyomi.source.model.decodeMemoBytes
+import eu.kanade.tachiyomi.source.model.encodeMemoBytes
+import eu.kanade.tachiyomi.source.model.safeMemo
 import eu.kanade.tachiyomi.util.chapter.ChapterUtil
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.protobuf.ProtoNumber
@@ -44,6 +47,8 @@ data class BackupManga(
     @ProtoNumber(104) var history: List<BackupHistory> = emptyList(),
     @ProtoNumber(105) var updateStrategy: UpdateStrategy = UpdateStrategy.ALWAYS_UPDATE,
     @ProtoNumber(108) var excludedScanlators: List<String> = emptyList(),
+    // Matches Mihon for extension-lib 1.6 memo
+    @ProtoNumber(112) var memo: ByteArray = ByteArray(0),
 
     // SY specific values
     @ProtoNumber(602) var customStatus: Int = 0,
@@ -77,6 +82,7 @@ data class BackupManga(
                 ?: -1
             chapter_flags = this@BackupManga.chapterFlags
             update_strategy = this@BackupManga.updateStrategy
+            memo = this@BackupManga.memo.decodeMemoBytes()
         }
     }
 
@@ -132,6 +138,7 @@ data class BackupManga(
                 chapterFlags = manga.chapter_flags,
                 updateStrategy = manga.update_strategy,
                 excludedScanlators = ChapterUtil.getScanlators(manga.filtered_scanlators),
+                memo = manga.safeMemo().encodeMemoBytes(),
             ).also { backupManga ->
                 customMangaManager?.getManga(manga)?.let {
                     backupManga.customTitle = it.title

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Chapter.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.data.database.models
 
 import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.decodeMemo
 import java.io.Serializable
 import yokai.domain.chapter.models.ChapterUpdate
 
@@ -62,6 +63,7 @@ interface Chapter : SChapter, Serializable {
             sourceOrder: Long,
             dateFetch: Long,
             dateUpload: Long,
+            memo: String,
         ): Chapter = create().apply {
             this.id = id
             this.manga_id = mangaId
@@ -76,6 +78,7 @@ interface Chapter : SChapter, Serializable {
             this.source_order = sourceOrder.toInt()
             this.date_fetch = dateFetch
             this.date_upload = dateUpload
+            this.memo = memo.decodeMemo()
         }
     }
 

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/LibraryManga.kt
@@ -40,6 +40,7 @@ data class LibraryManga(
             filteredScanlators: String?,
             updateStrategy: Long,
             coverLastModified: Long,
+            memo: String,
             // libraryManga
             total: Long,
             readCount: Double,
@@ -70,6 +71,7 @@ data class LibraryManga(
                 filteredScanlators = filteredScanlators,
                 updateStrategy = updateStrategy,
                 coverLastModified = coverLastModified,
+                memo = memo,
             ),
             read = readCount.roundToInt(),
             unread = maxOf((total - readCount).roundToInt(), 0),

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/Manga.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.domain.manga.models.Manga.Companion.TYPE_MANHWA
 import eu.kanade.tachiyomi.domain.manga.models.Manga.Companion.TYPE_WEBTOON
 import eu.kanade.tachiyomi.source.SourceManager
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.decodeMemo
 import eu.kanade.tachiyomi.ui.reader.settings.OrientationType
 import eu.kanade.tachiyomi.ui.reader.settings.ReadingModeType
 import eu.kanade.tachiyomi.util.isLocal
@@ -211,6 +212,7 @@ fun Manga.Companion.mapper(
     filteredScanlators: String?,
     updateStrategy: Long,
     coverLastModified: Long,
+    memo: String,
 ) = create(url, title, source).apply {
     this.id = id
     this.artist = artist
@@ -229,6 +231,7 @@ fun Manga.Companion.mapper(
     this.filtered_scanlators = filteredScanlators
     this.update_strategy = updateStrategy.let(updateStrategyAdapter::decode)
     this.cover_last_modified = coverLastModified
+    this.memo = memo.decodeMemo()
 }
 
 fun Manga.hasCustomCover(coverCache: CoverCache = Injekt.get()): Boolean {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaChapter.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaChapter.kt
@@ -26,6 +26,7 @@ class MangaChapter(val manga: Manga, val chapter: Chapter) {
             filteredScanlators: String?,
             updateStrategy: Long,
             coverLastModified: Long,
+            memo: String,
             // chapter
             chapterId: Long,
             _mangaId: Long,
@@ -40,6 +41,7 @@ class MangaChapter(val manga: Manga, val chapter: Chapter) {
             sourceOrder: Long,
             dateFetch: Long,
             dateUpload: Long,
+            chapterMemo: String,
         ) = MangaChapter(
             Manga.mapper(
                 id = mangaId,
@@ -62,6 +64,7 @@ class MangaChapter(val manga: Manga, val chapter: Chapter) {
                 filteredScanlators = filteredScanlators,
                 updateStrategy = updateStrategy,
                 coverLastModified = coverLastModified,
+                memo = memo,
             ),
             Chapter.mapper(
                 id = chapterId,
@@ -77,6 +80,7 @@ class MangaChapter(val manga: Manga, val chapter: Chapter) {
                 sourceOrder = sourceOrder,
                 dateFetch = dateFetch,
                 dateUpload = dateUpload,
+                memo = chapterMemo,
             ),
         )
     }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaChapterHistory.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/database/models/MangaChapterHistory.kt
@@ -40,6 +40,7 @@ data class MangaChapterHistory(val manga: Manga, val chapter: Chapter, val histo
             filteredScanlators: String?,
             updateStrategy: Long,
             coverLastModified: Long,
+            memo: String,
             // chapter
             chapterId: Long?,
             chapterMangaId: Long?,
@@ -54,6 +55,7 @@ data class MangaChapterHistory(val manga: Manga, val chapter: Chapter, val histo
             sourceOrder: Long?,
             dateFetch: Long?,
             dateUpload: Long?,
+            chapterMemo: String?,
             // history
             historyId: Long?,
             historyChapterId: Long?,
@@ -81,6 +83,7 @@ data class MangaChapterHistory(val manga: Manga, val chapter: Chapter, val histo
                 filteredScanlators = filteredScanlators,
                 updateStrategy = updateStrategy,
                 coverLastModified = coverLastModified,
+                memo = memo,
             )
 
             val chapter = try {
@@ -98,6 +101,7 @@ data class MangaChapterHistory(val manga: Manga, val chapter: Chapter, val histo
                     sourceOrder = sourceOrder!!,
                     dateFetch = dateFetch!!,
                     dateUpload = dateUpload!!,
+                    memo = chapterMemo.orEmpty(),
                 )
             } catch (_: NullPointerException) {
                 ChapterImpl()

--- a/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/util/chapter/ChapterSourceSync.kt
@@ -5,6 +5,8 @@ import eu.kanade.tachiyomi.data.download.DownloadManager
 import eu.kanade.tachiyomi.domain.manga.models.Manga
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.encodeMemo
+import eu.kanade.tachiyomi.source.model.safeMemo
 import eu.kanade.tachiyomi.source.online.HttpSource
 import java.util.*
 import uy.kohesive.injekt.Injekt
@@ -110,6 +112,7 @@ suspend fun syncChaptersWithSource(
                     dateUpload = chapter.date_upload,
                     chapterNumber = chapter.chapter_number.toDouble(),
                     sourceOrder = chapter.source_order.toLong(),
+                    memo = chapter.safeMemo().encodeMemo(),
                 )
                 toChange.add(update)
             }
@@ -225,5 +228,6 @@ private fun shouldUpdateDbChapter(dbChapter: Chapter, sourceChapter: Chapter): B
         dbChapter.name != sourceChapter.name ||
         dbChapter.date_upload != sourceChapter.date_upload ||
         dbChapter.chapter_number != sourceChapter.chapter_number ||
-        dbChapter.source_order != sourceChapter.source_order
+        dbChapter.source_order != sourceChapter.source_order ||
+        dbChapter.safeMemo() != sourceChapter.safeMemo()
 }

--- a/app/src/main/java/yokai/data/chapter/ChapterRepositoryImpl.kt
+++ b/app/src/main/java/yokai/data/chapter/ChapterRepositoryImpl.kt
@@ -3,6 +3,8 @@ package yokai.data.chapter
 import co.touchlab.kermit.Logger
 import eu.kanade.tachiyomi.data.database.models.Chapter
 import eu.kanade.tachiyomi.data.database.models.MangaChapter
+import eu.kanade.tachiyomi.source.model.encodeMemo
+import eu.kanade.tachiyomi.source.model.safeMemo
 import eu.kanade.tachiyomi.util.system.toInt
 import kotlinx.coroutines.flow.Flow
 import yokai.data.DatabaseHandler
@@ -117,7 +119,8 @@ class ChapterRepositoryImpl(private val handler: DatabaseHandler) : ChapterRepos
                     chapterNumber = update.chapterNumber,
                     sourceOrder = update.sourceOrder,
                     dateFetch = update.dateFetch,
-                    dateUpload = update.dateUpload
+                    dateUpload = update.dateUpload,
+                    memo = update.memo,
                 )
             }
         }
@@ -140,6 +143,7 @@ class ChapterRepositoryImpl(private val handler: DatabaseHandler) : ChapterRepos
                 sourceOrder = chapter.source_order.toLong(),
                 dateFetch = chapter.date_fetch,
                 dateUpload = chapter.date_upload,
+                memo = chapter.safeMemo().encodeMemo(),
             )
             chaptersQueries.selectLastInsertedRowId()
         }
@@ -161,6 +165,7 @@ class ChapterRepositoryImpl(private val handler: DatabaseHandler) : ChapterRepos
                     sourceOrder = chapter.source_order.toLong(),
                     dateFetch = chapter.date_fetch,
                     dateUpload = chapter.date_upload,
+                    memo = chapter.safeMemo().encodeMemo(),
                 )
                 val lastInsertId = chaptersQueries.selectLastInsertedRowId().executeAsOne()
                 chapter.copy().apply { id = lastInsertId }

--- a/app/src/main/java/yokai/data/manga/MangaRepositoryImpl.kt
+++ b/app/src/main/java/yokai/data/manga/MangaRepositoryImpl.kt
@@ -5,6 +5,8 @@ import eu.kanade.tachiyomi.data.database.models.LibraryManga
 import eu.kanade.tachiyomi.data.database.models.MangaCategory
 import eu.kanade.tachiyomi.data.database.models.mapper
 import eu.kanade.tachiyomi.domain.manga.models.Manga
+import eu.kanade.tachiyomi.source.model.encodeMemo
+import eu.kanade.tachiyomi.source.model.safeMemo
 import kotlinx.coroutines.flow.Flow
 import yokai.data.DatabaseHandler
 import yokai.data.updateStrategyAdapter
@@ -85,6 +87,7 @@ class MangaRepositoryImpl(private val handler: DatabaseHandler) : MangaRepositor
                     filteredScanlators = update.filteredScanlators,
                     updateStrategy = update.updateStrategy?.let(updateStrategyAdapter::encode),
                     coverLastModified = update.coverLastModified,
+                    memo = update.memo,
                     mangaId = update.id,
                 )
             }
@@ -113,6 +116,7 @@ class MangaRepositoryImpl(private val handler: DatabaseHandler) : MangaRepositor
                 filteredScanlators = manga.filtered_scanlators,
                 updateStrategy = manga.update_strategy.let(updateStrategyAdapter::encode),
                 coverLastModified = manga.cover_last_modified,
+                memo = manga.safeMemo().encodeMemo(),
             )
             mangasQueries.selectLastInsertedRowId()
         }

--- a/data/src/commonMain/sqldelight/tachiyomi/data/chapters.sq
+++ b/data/src/commonMain/sqldelight/tachiyomi/data/chapters.sq
@@ -14,6 +14,7 @@ CREATE TABLE chapters(
     source_order INTEGER NOT NULL,
     date_fetch INTEGER NOT NULL,
     date_upload INTEGER NOT NULL,
+    memo TEXT NOT NULL DEFAULT '{}',
     FOREIGN KEY(manga_id) REFERENCES mangas (_id)
     ON DELETE CASCADE
 );
@@ -110,7 +111,8 @@ UPDATE chapters SET
     chapter_number = coalesce(:chapterNumber, chapter_number),
     source_order = coalesce(:sourceOrder, source_order),
     date_fetch = coalesce(:dateFetch, date_fetch),
-    date_upload = coalesce(:dateUpload, date_upload)
+    date_upload = coalesce(:dateUpload, date_upload),
+    memo = coalesce(:memo, memo)
 WHERE _id = :chapterId;
 
 fixSourceOrder:
@@ -118,8 +120,8 @@ UPDATE chapters SET source_order = :sourceOrder
 WHERE url = :url AND manga_id = :mangaId;
 
 insert:
-INSERT INTO chapters (manga_id, url, name, scanlator, read, bookmark, last_page_read, pages_left, chapter_number, source_order, date_fetch, date_upload)
-VALUES (:mangaId, :url, :name, :scanlator, :read, :bookmark, :lastPageRead, :pagesLeft, :chapterNumber, :sourceOrder, :dateFetch, :dateUpload);
+INSERT INTO chapters (manga_id, url, name, scanlator, read, bookmark, last_page_read, pages_left, chapter_number, source_order, date_fetch, date_upload, memo)
+VALUES (:mangaId, :url, :name, :scanlator, :read, :bookmark, :lastPageRead, :pagesLeft, :chapterNumber, :sourceOrder, :dateFetch, :dateUpload, :memo);
 
 selectLastInsertedRowId:
 SELECT last_insert_rowid();

--- a/data/src/commonMain/sqldelight/tachiyomi/data/history.sq
+++ b/data/src/commonMain/sqldelight/tachiyomi/data/history.sq
@@ -215,7 +215,8 @@ JOIN (
         NULL AS last_page_read,
         NULL AS pages_left,
         NULL AS chapter_number,
-        NULL AS source_order
+        NULL AS source_order,
+        NULL AS memo
 ) AS C
 WHERE favorite = 1
 AND lower(title) LIKE '%' || :search || '%'

--- a/data/src/commonMain/sqldelight/tachiyomi/data/mangas.sq
+++ b/data/src/commonMain/sqldelight/tachiyomi/data/mangas.sq
@@ -20,7 +20,8 @@ CREATE TABLE mangas(
     date_added INTEGER,
     filtered_scanlators TEXT,
     update_strategy INTEGER NOT NULL DEFAULT 0,
-    cover_last_modified INTEGER NOT NULL DEFAULT 0
+    cover_last_modified INTEGER NOT NULL DEFAULT 0,
+    memo TEXT NOT NULL DEFAULT '{}'
 );
 
 CREATE INDEX mangas_url_index ON mangas(url);
@@ -59,8 +60,8 @@ WHERE favorite = 0 AND _id IN (
 );
 
 insert:
-INSERT INTO mangas (source, url, artist, author, description, genre, title, status, thumbnail_url, favorite, last_update, initialized, viewer, hide_title, chapter_flags, date_added, filtered_scanlators, update_strategy, cover_last_modified)
-VALUES (:source, :url, :artist, :author, :description, :genre, :title, :status, :thumbnailUrl, :favorite, :lastUpdate, :initialized, :viewer, :hideTitle, :chapterFlags, :dateAdded, :filteredScanlators, :updateStrategy, :coverLastModified);
+INSERT INTO mangas (source, url, artist, author, description, genre, title, status, thumbnail_url, favorite, last_update, initialized, viewer, hide_title, chapter_flags, date_added, filtered_scanlators, update_strategy, cover_last_modified, memo)
+VALUES (:source, :url, :artist, :author, :description, :genre, :title, :status, :thumbnailUrl, :favorite, :lastUpdate, :initialized, :viewer, :hideTitle, :chapterFlags, :dateAdded, :filteredScanlators, :updateStrategy, :coverLastModified, :memo);
 
 update:
 UPDATE mangas SET
@@ -82,7 +83,8 @@ UPDATE mangas SET
     date_added = coalesce(:dateAdded, date_added),
     filtered_scanlators = coalesce(:filteredScanlators, filtered_scanlators),
     update_strategy = coalesce(:updateStrategy, update_strategy),
-    cover_last_modified = coalesce(:coverLastModified, cover_last_modified)
+    cover_last_modified = coalesce(:coverLastModified, cover_last_modified),
+    memo = coalesce(:memo, memo)
 WHERE _id = :mangaId;
 
 selectLastInsertedRowId:

--- a/data/src/commonMain/sqldelight/tachiyomi/migrations/29.sqm
+++ b/data/src/commonMain/sqldelight/tachiyomi/migrations/29.sqm
@@ -1,0 +1,41 @@
+ALTER TABLE chapters
+ADD COLUMN memo TEXT NOT NULL DEFAULT '{}';
+
+ALTER TABLE mangas
+ADD COLUMN memo TEXT NOT NULL DEFAULT '{}';
+
+DROP VIEW IF EXISTS library_view;
+CREATE VIEW library_view AS
+SELECT
+    M.*,
+    coalesce(C.total, 0) AS total,
+    coalesce(C.read_count, 0) AS has_read,
+    coalesce(C.bookmark_count, 0) AS bookmark_count,
+    coalesce(MC.category_id, 0) AS category,
+    coalesce(C.latestUpload, 0) AS latestUpload,
+    coalesce(C.lastRead, 0) AS lastRead,
+    coalesce(C.lastFetch, 0) AS lastFetch
+FROM mangas AS M
+LEFT JOIN (
+    SELECT
+        chapters.manga_id,
+        count(*) AS total,
+        sum(read) AS read_count,
+        sum(bookmark) AS bookmark_count,
+        coalesce(max(chapters.date_upload), 0) AS latestUpload,
+        coalesce(max(history.history_last_read), 0) AS lastRead,
+        coalesce(max(chapters.date_fetch), 0) AS lastFetch
+    FROM chapters
+    LEFT JOIN scanlators_view AS filtered_scanlators
+    ON chapters.manga_id = filtered_scanlators.manga_id
+    AND chapters.scanlator = filtered_scanlators.name
+    LEFT JOIN history
+    ON chapters._id = history.history_chapter_id
+    WHERE filtered_scanlators.name IS NULL
+    GROUP BY chapters.manga_id
+) AS C
+ON M._id = C.manga_id
+LEFT JOIN (SELECT * FROM mangas_categories) AS MC
+ON MC.manga_id = M._id
+WHERE M.favorite = 1
+ORDER BY M.title;

--- a/domain/src/commonMain/kotlin/eu/kanade/tachiyomi/domain/manga/models/Manga.kt
+++ b/domain/src/commonMain/kotlin/eu/kanade/tachiyomi/domain/manga/models/Manga.kt
@@ -1,6 +1,7 @@
 package eu.kanade.tachiyomi.domain.manga.models
 
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.encodeMemo
 import eu.kanade.tachiyomi.source.model.safeMemo
 import java.util.Locale
 import yokai.domain.manga.models.MangaUpdate
@@ -218,6 +219,7 @@ interface Manga : SManga {
             dateAdded = date_added,
             filteredScanlators = filtered_scanlators,
             updateStrategy = update_strategy,
+            memo = safeMemo().encodeMemo(),
         )
     }
 

--- a/domain/src/commonMain/kotlin/yokai/domain/chapter/models/ChapterUpdate.kt
+++ b/domain/src/commonMain/kotlin/yokai/domain/chapter/models/ChapterUpdate.kt
@@ -14,4 +14,5 @@ data class ChapterUpdate(
     val sourceOrder: Long? = null,
     val dateFetch: Long? = null,
     val dateUpload: Long? = null,
+    val memo: String? = null,
 )

--- a/domain/src/commonMain/kotlin/yokai/domain/manga/models/MangaUpdate.kt
+++ b/domain/src/commonMain/kotlin/yokai/domain/manga/models/MangaUpdate.kt
@@ -23,4 +23,5 @@ data class MangaUpdate(
     var hideTitle: Boolean? = null,
     var filteredScanlators: String? = null,
     var coverLastModified: Long? = null,
+    var memo: String? = null,
 )

--- a/source/api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/Memo.kt
+++ b/source/api/src/commonMain/kotlin/eu/kanade/tachiyomi/source/model/Memo.kt
@@ -1,0 +1,22 @@
+package eu.kanade.tachiyomi.source.model
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.jsonObject
+
+private val json = Json { ignoreUnknownKeys = true }
+private val emptyMemo = JsonObject(emptyMap())
+
+fun JsonObject.encodeMemo(): String =
+    if (isEmpty()) "{}" else json.encodeToString(JsonObject.serializer(), this)
+
+fun String.decodeMemo(): JsonObject {
+    if (isBlank() || this == "{}") return emptyMemo
+    return runCatching { json.parseToJsonElement(this).jsonObject }.getOrDefault(emptyMemo)
+}
+
+fun ByteArray.decodeMemoBytes(): JsonObject =
+    if (isEmpty()) emptyMemo else decodeToString().decodeMemo()
+
+fun JsonObject.encodeMemoBytes(): ByteArray =
+    if (isEmpty()) ByteArray(0) else encodeMemo().encodeToByteArray()


### PR DESCRIPTION
## Summary
- Persist extension-lib 1.6 `memo` on chapters and manga (SQLDelight migration 29). Keiyoushi 1.6 sources such as Asura, Kayn, Vortex, and Hive store required slugs in that field; Yokai was dropping it on DB round-trip, which produced a repeating `Refresh Chapter List` error.
- Update existing chapters on refresh when memo changes, so a one-time chapter-list refresh writes the missing data.
- Include memo in protobuf backups using Mihon-compatible field numbers (chapter 13, manga 112).


https://github.com/user-attachments/assets/62db7820-4cba-449a-96c5-461f7c9951d0


Fixes https://github.com/null2264/yokai/issues/691
Fixes https://github.com/null2264/yokai/issues/695

## Test plan
- [ ] Install this build over an existing library (migration 29 applies).
- [ ] Open an affected series (Asura Scans is the known case) and pull-to-refresh the chapter list once.
- [ ] Open a chapter; it should load instead of toasting `Refresh Chapter List` and closing the reader.
- [ ] Kill and reopen the app, then open the same chapter again without another refresh.
- [ ] Confirm unrelated sources still open chapters as before.